### PR TITLE
DM-21212: Update existing cp_pipe tasks to pipelineTasks

### DIFF
--- a/bin.src/blessCalibration.py
+++ b/bin.src/blessCalibration.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+#
+# This file is part of cp_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Mark cp_pipe generated calibrations as valid, and register them with
+the butler with an appropriate use date range.
+"""
+from lsst.cp.pipe.cpCertify import BlessCalibration
+
+import argparse
+import logging
+
+import lsst.log
+from lsst.log import Log
+
+from lsst.daf.butler import Butler
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("root", help="Path to butler to use")
+    parser.add_argument("inputCollection", help="Input collection to pull from.")
+    parser.add_argument("outputCollection", help="Output collection to add to.")
+    parser.add_argument("datasetTypeName", help="Dataset type to bless.")
+
+    parser.add_argument("-v", "--verbose", action="store_const", dest="logLevel",
+                        default=Log.INFO, const=Log.DEBUG,
+                        help="Set the log level to DEBUG.")
+    parser.add_argument("-b", "--beginDate",
+                        help="Start date for using the calibration")
+    parser.add_argument("-e", "--endDate",
+                        help="End date for using the calibration")
+    parser.add_argument("-s", "--skipCalibrationLabel", action="store_true",
+                        default=False, dest="skipCL",
+                        help="Do not attempt to register the calibration label.")
+
+    args = parser.parse_args()
+    log = Log.getLogger("lsst.daf.butler")
+    log.setLevel(args.logLevel)
+
+    # DM-22527: Clean up syntax/log handling in gen3 repo scripts.
+    lgr = logging.getLogger("lsst.daf.butler")
+    lgr.setLevel(logging.INFO if args.logLevel == Log.INFO else logging.DEBUG)
+    lgr.addHandler(lsst.log.LogHandler())
+
+    butler = Butler(args.root, run=args.inputCollection)
+
+    # Do the thing.
+    crozier = BlessCalibration(butler=butler,
+                               inputCollection=args.inputCollection,
+                               outputCollection=args.outputCollection)
+
+    crozier.findInputs(args.datasetTypeName)
+    if not args.skipCL:
+        crozier.addCalibrationLabel(beginDate=args.beginDate, endDate=args.endDate)
+    crozier.registerCalibrations(args.datasetTypeName)

--- a/pipelines/cpBias.yaml
+++ b/pipelines/cpBias.yaml
@@ -1,0 +1,30 @@
+description: cp_pipe BIAS calibration construction
+tasks:
+  isr:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.outputExposure: 'cpBiasProc'
+      doBias: False
+      doVariance: True
+      doLinearize: False
+      doCrosstalk: False
+      doDefect: True
+      doNanMasking: True
+      doInterpolate: True
+      doBrighterFatter: False
+      doDark: False
+      doFlat: False
+      doApplyGains: False
+      doFringe: False
+  cpCombine:
+    class: lsst.cp.pipe.cpCombine.CalibCombineTask
+    config:
+      connections.inputExps: 'cpBiasProc'
+      connections.outputData: 'biasProposal'
+      calibrationType: 'bias'
+      exposureScaling: "None"
+contracts:
+  - isr.doBias == False
+  - cpCombine.calibrationType == "bias"
+  - cpCombine.exposureScaling == "None"

--- a/pipelines/cpDark.yaml
+++ b/pipelines/cpDark.yaml
@@ -1,0 +1,36 @@
+description: cp_pipe DARK calibration construction
+tasks:
+  isr:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.outputExposure: 'cpDarkIsr'
+      doBias: True
+      doVariance: True
+      doLinearize: True
+      doCrosstalk: True
+      doDefect: True
+      doNanMasking: True
+      doInterpolate: True
+      doBrighterFatter: False
+      doDark: False
+      doFlat: False
+      doApplyGains: False
+      doFringe: False
+  cpDark:
+    class: lsst.cp.pipe.cpDarkTask.CpDarkTask
+    config:
+      connections.inputExp: 'cpDarkIsr'
+      connections.outputExp: 'cpDarkProc'
+  cpCombine:
+    class: lsst.cp.pipe.cpCombine.CalibCombineTask
+    config:
+      connections.inputExps: 'cpDarkProc'
+      connections.outputData: 'darkProposal'
+      calibrationType: 'dark'
+      exposureScaling: "DarkTime"
+      python: config.mask.append("CR")
+contracts:
+  - isr.doDark == False
+  - cpCombine.calibrationType == "dark"
+  - cpCombine.exposureScaling == "DarkTime"

--- a/pipelines/cpFlat.yaml
+++ b/pipelines/cpFlat.yaml
@@ -1,0 +1,41 @@
+description: cp_pipe FLAT calibration construction optimized for single-CCD cameras
+tasks:
+  isr:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.outputExposure: 'cpFlatProc'
+      doBias: True
+      doVariance: True
+      doLinearize: True
+      doCrosstalk: True
+      doDefect: True
+      doNanMasking: True
+      doInterpolate: True
+      doDark: True
+      doBrighterFatter: False
+      doFlat: False
+      doFringe: False
+      doApplyGains: False
+  cpFlatMeasure:
+    class: lsst.cp.pipe.cpFlatNormTask.CpFlatMeasureTask
+    config:
+      connections.inputExp: 'cpFlatProc'
+      connections.outputStats: 'flatStats'
+  cpFlatNorm:
+    class: lsst.cp.pipe.cpFlatNormTask.CpFlatNormalizationTask
+    config:
+      connections.inputMDs: 'flatStats'
+      connections.outputScales: 'cpFlatNormScales'
+  cpCombine:
+    class: lsst.cp.pipe.cpCombine.CalibCombineTask
+    config:
+      connections.inputExps: 'cpFlatProc'
+      connections.inputScales: 'cpFlatNormScales'
+      connections.outputData: 'flatProposal'
+      calibrationType: 'flat'
+      calibrationDimensions: ['physical_filter']
+      exposureScaling: InputList
+      scalingLevel: AMP
+contracts:
+  - isr.doFlat == False

--- a/pipelines/cpFlatSingleChip.yaml
+++ b/pipelines/cpFlatSingleChip.yaml
@@ -1,0 +1,31 @@
+description: cp_pipe FLAT calibration construction
+tasks:
+  isr:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.outputExposure: 'cpFlatProc'
+      doBias: True
+      doVariance: True
+      doLinearize: True
+      doCrosstalk: True
+      doDefect: True
+      doNanMasking: True
+      doInterpolate: True
+      doDark: True
+      doBrighterFatter: False
+      doFlat: False
+      doFringe: False
+      doApplyGains: False
+  cpCombine:
+    class: lsst.cp.pipe.cpCombine.CalibCombineTask
+    config:
+      connections.inputExps: 'cpFlatProc'
+      connections.outputData: 'flatProposal'
+      calibrationType: 'flat'
+      calibrationDimensions: ['physical_filter']
+      exposureScaling: None
+      exposureScaling: MeanStats
+contracts:
+  - isr.doFlat == False
+  - cpCombine.calibrationType == "flat"

--- a/pipelines/cpFringe.yaml
+++ b/pipelines/cpFringe.yaml
@@ -1,0 +1,35 @@
+description: cp_pipe FRINGE calibration construction
+tasks:
+  isr:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.outputExposure: 'cpFringeIsr'
+      doBias: True
+      doVariance: True
+      doLinearize: True
+      doCrosstalk: True
+      doDefect: True
+      doNanMasking: True
+      doInterpolate: True
+      doDark: True
+      doFlat: True
+      doApplyGains: False
+      doFringe: False
+  cpFringe:
+    class: lsst.cp.pipe.cpFringeTask.CpFringeTask
+    config:
+      connections.inputExp: 'cpFringeIsr'
+      connections.outputExp: 'cpFringeProc'
+  cpCombine:
+    class: lsst.cp.pipe.cpCombine.CalibCombineTask
+    config:
+      connections.inputExps: 'cpFringeProc'
+      connections.outputData: 'fringeProposal'
+      calibrationType: 'fringe'
+      calibrationDimensions: ['physical_filter']
+      exposureScaling: "None"
+contracts:
+  - isr.doFringe == False
+  - cpCombine.calibrationType == "fringe"
+  - cpCombine.exposureScaling == "None"

--- a/python/lsst/cp/pipe/__init__.py
+++ b/python/lsst/cp/pipe/__init__.py
@@ -30,3 +30,4 @@ except ImportError:
 from .makeBrighterFatterKernel import *
 from .defects import *
 from .ptc import *
+from .cpCombine import *

--- a/python/lsst/cp/pipe/__init__.py
+++ b/python/lsst/cp/pipe/__init__.py
@@ -31,3 +31,4 @@ from .makeBrighterFatterKernel import *
 from .defects import *
 from .ptc import *
 from .cpCombine import *
+from .cpCertify import *

--- a/python/lsst/cp/pipe/cpCertify.py
+++ b/python/lsst/cp/pipe/cpCertify.py
@@ -1,0 +1,214 @@
+# This file is part of cp_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import datetime
+from astropy.time import Time
+
+import lsst.pex.config as pexConfig
+import lsst.pipe.base as pipeBase
+from lsst.daf.butler import DatasetType
+
+
+class BlessCalibration(pipeBase.Task):
+    """Create a way to bless existing calibration products.
+
+    The inputs are assumed to have been constructed via cp_pipe, and
+    already exist in the butler.
+
+    Parameters
+    ----------
+    butler : `lsst.daf.butler.Butler`
+        Butler repository to use.
+    inputCollection : `str`
+        Data collection to pull calibrations from.
+    outputCollection : `str`
+        Data collection to store final calibrations.
+    **kwargs :
+        Additional arguments forwarded to `lsst.pipe.base.Task.__init__`.
+    """
+    _DefaultName = 'BlessCalibration'
+    ConfigClass = pexConfig.Config
+
+    def __init__(self, *, butler, inputCollection, outputCollection,
+                 **kwargs):
+        super().__init__(**kwargs)
+        self.butler = butler
+        self.registry = self.butler.registry
+        self.inputCollection = inputCollection
+        self.outputCollection = outputCollection
+
+        self.calibrationLabel = None
+        self.instrument = None
+
+    def findInputs(self, datasetTypeName, inputDatasetTypeName=None):
+        """Find and prepare inputs for blessing.
+
+        Parameters
+        ----------
+        datasetTypeName : `str`
+            Dataset that will be blessed.
+        inputDatasetTypeName : `str`, optional
+            Dataset name for the input datasets.  Default to
+            datasetTypeName + "Proposal".
+
+        Raises
+        ------
+        RuntimeError
+            Raised if no input datasets found or if the calibration
+            label exists and is not empty.
+        """
+        if inputDatasetTypeName is None:
+            inputDatasetTypeName = datasetTypeName + "Proposal"
+
+        self.inputValues = list(self.registry.queryDatasets(inputDatasetTypeName,
+                                                            collections=[self.inputCollection],
+                                                            deduplicate=True))
+        # THIS IS INELEGANT AT BEST => fixed by passing deduplicate=True above.
+        # self.inputValues = list(filter(lambda vv: self.inputCollection in vv.run, self.inputValues))
+
+        if len(self.inputValues) == 0:
+            raise RuntimeError(f"No inputs found for dataset {inputDatasetTypeName} "
+                               f"in {self.inputCollection}")
+
+        # Construct calibration label and choose instrument to use.
+        self.calibrationLabel = f"{datasetTypeName}/{self.inputCollection}"
+        self.instrument = self.inputValues[0].dataId['instrument']
+
+        # Prepare combination of new data ids and object data:
+        self.newDataIds = [value.dataId for value in self.inputValues]
+
+        self.objects = [self.butler.get(value) for value in self.inputValues]
+
+    def registerCalibrations(self, datasetTypeName):
+        """Add blessed inputs to the output collection.
+
+        Parameters
+        ----------
+        datasetTypeName : `str`
+            Dataset type these calibrations will be registered for.
+        """
+        # Find/make the run we will use for the output
+        self.registry.registerRun(self.outputCollection)
+        self.butler.run = self.outputCollection
+        self.butler.collection = None
+
+        try:
+            self.registerDatasetType(datasetTypeName, self.newDataIds[0])
+        except Exception as e:
+            print(f"Could not registerDatasetType {datasetTypeName}.  Failure {e}?")
+
+        with self.butler.transaction():
+            for newId, data in zip(self.newDataIds, self.objects):
+                data = self.convertStorageClass(data, datasetTypeName)
+
+                self.butler.put(data, datasetTypeName, dataId=newId,
+                                calibration_label=self.calibrationLabel,
+                                producer=None)
+
+    def convertStorageClass(self, data, datasetTypeName):
+        """Switch from an exposure to the image type expected.
+
+        Parameters
+        ----------
+        data : `lsst.afw.image.Exposure`
+            Input exposure data to convert.
+        datasetTypeName : `str`
+            Dataset type that will be registered
+
+        Returns
+        -------
+        data : `lsst.afw.image.Image` or `lsst.afw.image.MaskedImage`
+            Converted image data to register.
+        """
+        if datasetTypeName in ('bias', 'dark'):
+            data = data.getImage()
+        # elif datasetTypeName in ('flat', ):
+        #     data = data.getMaskedImage()
+
+        return data
+
+    def registerDatasetType(self, datasetTypeName, dataId):
+        """Ensure registry can handle this dataset type.
+
+        Parameters
+        ----------
+        datasetTypeName : `str`
+            Name of the dataset that will be registered.
+        dataId : `lsst.daf.butler.dataId`
+            Data ID providing the list of dimensions for the new
+            datasetType.
+        """
+        storageClassMap = {'bias': 'ImageF',
+                           'dark': 'ImageF',
+                           'flat': 'ExposureF',
+                           }
+        storageClass = storageClassMap.get(datasetTypeName, 'ExposureF')
+
+        dimensionArray = set(list(dataId.keys()) + ["calibration_label"])
+        datasetType = DatasetType(datasetTypeName,
+                                  dimensionArray,
+                                  storageClass,
+                                  universe=self.butler.registry.dimensions)
+        self.butler.registry.registerDatasetType(datasetType)
+
+    def addCalibrationLabel(self, name=None, instrument=None,
+                            beginDate="1970-01-01", endDate="2038-12-31"):
+
+        """Method to allow tasks to add calibration_label for master calibrations.
+
+        Parameters
+        ----------
+        name : `str`, optional
+            A unique string for the calibration_label key.
+        instrument : `str`, optional
+            Instrument this calibration is for.
+        beginDate : `str`, optional
+            An ISO 8601 date string for the beginning of the valid date range.
+        endDate : `str`, optional
+            An ISO 8601 date string for the end of the valid date range.
+
+        Raises
+        ------
+        RuntimeError :
+            Raised if the instrument or calibration_label name are not set.
+        """
+        if name is None:
+            name = self.calibrationLabel
+        if instrument is None:
+            instrument = self.instrument
+        if name is None and instrument is None:
+            raise RuntimeError("Instrument and calibration_label name not set.")
+
+        try:
+            existingValues = self.registry.queryDimensions(['calibration_label'],
+                                                           instrument=self.instrument,
+                                                           calibration_label=name)
+            existingValues = [a for a in existingValues]
+            print(f"Found {len(existingValues)} Entries for {self.calibrationLabel}")
+        except LookupError:
+            self.butler.registry.insertDimensionData(
+                "calibration_label",
+                {
+                    "name": name,
+                    "instrument": instrument,
+                    "datetime_begin": Time(datetime.datetime.fromisoformat(beginDate), scale='utc'),
+                    "datetime_end": Time(datetime.datetime.fromisoformat(endDate), scale='utc'),
+                }
+            )

--- a/python/lsst/cp/pipe/cpCombine.py
+++ b/python/lsst/cp/pipe/cpCombine.py
@@ -104,7 +104,7 @@ class CalibCombineConnections(pipeBase.PipelineTaskConnections,
     inputScales = cT.Input(
         name="cpScales",
         doc="Input scale factors to use.",
-        storageClass="StructuredDataDictYaml",
+        storageClass="StructuredDataDict",
         dimensions=("instrument", ),
         multiple=False,
     )

--- a/python/lsst/cp/pipe/cpCombine.py
+++ b/python/lsst/cp/pipe/cpCombine.py
@@ -1,0 +1,581 @@
+# This file is part of cp_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import numpy as np
+import time
+
+import lsst.pex.config as pexConfig
+import lsst.pipe.base as pipeBase
+import lsst.pipe.base.connectionTypes as cT
+import lsst.afw.math as afwMath
+import lsst.afw.image as afwImage
+
+from lsst.geom import Point2D
+from lsst.log import Log
+from astro_metadata_translator import merge_headers, ObservationGroup
+from astro_metadata_translator.serialize import dates_to_fits
+
+
+# CalibStatsConfig/CalibStatsTask from pipe_base/constructCalibs.py
+class CalibStatsConfig(pexConfig.Config):
+    """Parameters controlling the measurement of background statistics.
+    """
+    stat = pexConfig.Field(
+        dtype=int,
+        default=int(afwMath.MEANCLIP),
+        doc="Statistic to use to estimate background (from lsst.afw.math)",
+    )
+    clip = pexConfig.Field(
+        dtype=float,
+        default=3.0,
+        doc="Clipping threshold for background",
+    )
+    nIter = pexConfig.Field(
+        dtype=int,
+        default=3,
+        doc="Clipping iterations for background",
+    )
+    mask = pexConfig.ListField(
+        dtype=str,
+        default=["DETECTED", "BAD", "NO_DATA"],
+        doc="Mask planes to reject",
+    )
+
+
+class CalibStatsTask(pipeBase.Task):
+    """Measure statistics on the background
+
+    This can be useful for scaling the background, e.g., for flats and fringe frames.
+    """
+    ConfigClass = CalibStatsConfig
+
+    def run(self, exposureOrImage):
+        """Measure a particular statistic on an image (of some sort).
+
+        Parameters
+        ----------
+        exposureOrImage : `lsst.afw.image.Exposure`, `lsst.afw.image.MaskedImage`, or `lsst.afw.image.Image`
+           Exposure or image to calculate statistics on.
+
+        Returns
+        -------
+        results : float
+           Resulting statistic value.
+        """
+        stats = afwMath.StatisticsControl(self.config.clip, self.config.nIter,
+                                          afwImage.Mask.getPlaneBitMask(self.config.mask))
+        try:
+            image = exposureOrImage.getMaskedImage()
+        except Exception:
+            try:
+                image = exposureOrImage.getImage()
+            except Exception:
+                image = exposureOrImage
+
+        return afwMath.makeStatistics(image, self.config.stat, stats).getValue()
+
+
+class CalibCombineConnections(pipeBase.PipelineTaskConnections,
+                              dimensions=("instrument", "detector")):
+    inputExps = cT.Input(
+        name="cpInputs",
+        doc="Input pre-processed exposures to combine.",
+        storageClass="ExposureF",
+        dimensions=("instrument", "detector", "exposure"),
+        multiple=True,
+    )
+    inputScales = cT.Input(
+        name="cpScales",
+        doc="Input scale factors to use.",
+        storageClass="StructuredDataDictYaml",
+        dimensions=("instrument", ),
+        multiple=False,
+    )
+
+    outputData = cT.Output(
+        name="cpProposal",
+        doc="Output combined proposed calibration.",
+        storageClass="ExposureF",
+        dimensions=("instrument", "detector"),
+    )
+
+    def __init__(self, *, config=None):
+        super().__init__(config=config)
+
+        if config and len(config.calibrationDimensions) != 0:
+            newDimensions = tuple(config.calibrationDimensions)
+            newOutputData = cT.Output(
+                name=self.outputData.name,
+                doc=self.outputData.doc,
+                storageClass=self.outputData.storageClass,
+                dimensions=self.allConnections['outputData'].dimensions + newDimensions
+            )
+            self.dimensions.update(config.calibrationDimensions)
+            self.outputData = newOutputData
+
+            if config.exposureScaling == 'InputList':
+                newInputScales = cT.PrerequisiteInput(
+                    name=self.inputScales.name,
+                    doc=self.inputScales.doc,
+                    storageClass=self.inputScales.storageClass,
+                    dimensions=self.allConnections['inputScales'].dimensions + newDimensions
+                )
+                self.dimensions.update(config.calibrationDimensions)
+                self.inputScales = newInputScales
+
+
+# CalibCombineConfig/CalibCombineTask from pipe_base/constructCalibs.py
+class CalibCombineConfig(pipeBase.PipelineTaskConfig,
+                         pipelineConnections=CalibCombineConnections):
+    """Configuration for combining calib exposures.
+    """
+    calibrationType = pexConfig.Field(
+        dtype=str,
+        default="calibration",
+        doc="Name of calibration to be generated.",
+    )
+    calibrationDimensions = pexConfig.ListField(
+        dtype=str,
+        default=[],
+        doc="List of updated dimensions to append to output."
+    )
+
+    exposureScaling = pexConfig.ChoiceField(
+        dtype=str,
+        allowed={
+            "None": "No scaling used.",
+            "ExposureTime": "Scale inputs by their exposure time.",
+            "DarkTime": "Scale inputs by their dark time.",
+            "MeanStats": "Scale inputs based on their mean values.",
+            "InputList": "Scale inputs based on a list of values.",
+        },
+        default=None,
+        doc="Scaling to be applied to each input exposure.",
+    )
+    scalingLevel = pexConfig.ChoiceField(
+        dtype=str,
+        allowed={
+            "DETECTOR": "Scale by detector.",
+            "AMP": "Scale by amplifier.",
+        },
+        default="DETECTOR",
+        doc="Region to scale.",
+    )
+    maxVisitsToCalcErrorFromInputVariance = pexConfig.Field(
+        dtype=int,
+        default=5,
+        doc="Maximum number of visits to estimate variance from input variance, not per-pixel spread",
+    )
+
+    doVignette = pexConfig.Field(
+        dtype=bool,
+        default=False,
+        doc="Copy vignette polygon to output and censor vignetted pixels?"
+    )
+
+    mask = pexConfig.ListField(
+        dtype=str,
+        default=["SAT", "DETECTED", "INTRP"],
+        doc="Mask planes to respect",
+    )
+    combine = pexConfig.Field(
+        dtype=int,
+        default=int(afwMath.MEANCLIP),
+        doc="Statistic to use for combination (from lsst.afw.math)",
+    )
+    clip = pexConfig.Field(
+        dtype=float,
+        default=3.0,
+        doc="Clipping threshold for combination",
+    )
+    nIter = pexConfig.Field(
+        dtype=int,
+        default=3,
+        doc="Clipping iterations for combination",
+    )
+    stats = pexConfig.ConfigurableField(
+        target=CalibStatsTask,
+        doc="Background statistics configuration",
+    )
+
+
+class CalibCombineTask(pipeBase.PipelineTask,
+                       pipeBase.CmdLineTask):
+    """Task to combine calib exposures."""
+    ConfigClass = CalibCombineConfig
+    _DefaultName = 'cpCombine'
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.makeSubtask("stats")
+
+    def runQuantum(self, butlerQC, inputRefs, outputRefs):
+        inputs = butlerQC.get(inputRefs)
+
+        dimensions = [exp.dataId.byName() for exp in inputRefs.inputExps]
+        inputs['inputDims'] = dimensions
+
+        outputs = self.run(**inputs)
+        butlerQC.put(outputs, outputRefs)
+
+    def run(self, inputExps, inputScales=None, inputDims=None):
+        """Combine calib exposures for a single detector.
+
+        Parameters
+        ----------
+        inputExps : `list` [`lsst.afw.image.Exposure`]
+            Input list of exposures to combine.
+        inputScales : `dict` [`dict` [`dict` [`float`]]], optional
+            Dictionary of scales, indexed by detector (`int`),
+            amplifier (`int`), and exposure (`int`).  Used for
+            'inputList' scaling.
+        inputDims : `list` [`dict`]
+            List of dictionaries of input data dimensions/values.
+            Each list entry should contain:
+
+            ``"exposure"``
+                exposure id value (`int`)
+            ``"detector"``
+                detector id value (`int`)
+
+        Returns
+        -------
+        combinedExp : `lsst.afw.image.Exposure`
+            Final combined exposure generated from the inputs.
+
+        Raises
+        ------
+        RuntimeError
+            Raised if no input data is found.  Also raised if
+            config.exposureScaling == InputList, and a necessary scale
+            was not found.
+        """
+        width, height = self.getDimensions(inputExps)
+        stats = afwMath.StatisticsControl(self.config.clip, self.config.nIter,
+                                          afwImage.Mask.getPlaneBitMask(self.config.mask))
+        numExps = len(inputExps)
+        if numExps < 1:
+            raise RuntimeError("No valid input data")
+        if numExps < self.config.maxVisitsToCalcErrorFromInputVariance:
+            stats.setCalcErrorFromInputVariance(True)
+
+        # Create output exposure for combined data.
+        combined = afwImage.MaskedImageF(width, height)
+        combinedExp = afwImage.makeExposure(combined)
+
+        # Apply scaling:
+        expScales = []
+        if inputDims is None:
+            inputDims = [dict() for i in inputExps]
+
+        for index, (exp, dims) in enumerate(zip(inputExps, inputDims)):
+            scale = 1.0
+            if exp is None:
+                self.log.warn("Input %d is None (%s); unable to scale exp.", index, dims)
+                continue
+
+            if self.config.exposureScaling == "ExposureTime":
+                scale = exp.getInfo().getVisitInfo().getExposureTime()
+            elif self.config.exposureScaling == "DarkTime":
+                scale = exp.getInfo().getVisitInfo().getDarkTime()
+            elif self.config.exposureScaling == "MeanStats":
+                scale = self.stats.run(exp)
+            elif self.config.exposureScaling == "InputList":
+                visitId = dims.get('exposure', None)
+                detectorId = dims.get('detector', None)
+                if visitId is None or detectorId is None:
+                    raise RuntimeError(f"Could not identify scaling for input {index} ({dims})")
+                if detectorId not in inputScales['expScale']:
+                    raise RuntimeError(f"Could not identify a scaling for input {index}"
+                                       f" detector {detectorId}")
+
+                if self.config.scalingLevel == "DETECTOR":
+                    if visitId not in inputScales['expScale'][detectorId]:
+                        raise RuntimeError(f"Could not identify a scaling for input {index}"
+                                           f"detector {detectorId} visit {visitId}")
+                    scale = inputScales['expScale'][detectorId][visitId]
+                elif self.config.scalingLevel == 'AMP':
+                    scale = [inputScales['expScale'][detectorId][amp.getName()][visitId]
+                             for amp in exp.getDetector()]
+                else:
+                    raise RuntimeError(f"Unknown scaling level: {self.config.scalingLevel}")
+            elif self.config.exposureScaling == 'None':
+                scale = 1.0
+            else:
+                raise RuntimeError(f"Unknown scaling type: {self.config.exposureScaling}.")
+
+            expScales.append(scale)
+            self.log.info("Scaling input %d by %s", index, scale)
+            self.applyScale(exp, scale)
+
+        self.combine(combined, inputExps, stats)
+
+        self.interpolateNans(combined)
+
+        if self.config.doVignette:
+            polygon = inputExps[0].getInfo().getValidPolygon()
+            VignetteExposure(combined, polygon=polygon, doUpdateMask=True,
+                             doSetValue=True, vignetteValue=0.0)
+
+        # Combine headers
+        self.combineHeaders(inputExps, combinedExp,
+                            calibType=self.config.calibrationType, scales=expScales)
+
+        # Return
+        return pipeBase.Struct(
+            outputData=combinedExp,
+        )
+
+    def getDimensions(self, expList):
+        """Get dimensions of the inputs.
+
+        Parameters
+        ----------
+        expList : `list` [`lsst.afw.image.Exposure`]
+            Exps to check the sizes of.
+
+        Returns
+        -------
+        width, height : `int`
+            Unique set of input dimensions.
+        """
+        dimList = [exp.getDimensions() for exp in expList if exp is not None]
+        return self.getSize(dimList)
+
+    def getSize(self, dimList):
+        """Determine a consistent size, given a list of image sizes.
+
+        Parameters
+        -----------
+        dimList : iterable of `tuple` (`int`, `int`)
+            List of dimensions.
+
+        Raises
+        ------
+        RuntimeError
+            If input dimensions are inconsistent.
+
+        Returns
+        --------
+        width, height : `int`
+            Common dimensions.
+        """
+        dim = set((w, h) for w, h in dimList)
+        if len(dim) != 1:
+            raise RuntimeError("Inconsistent dimensions: %s" % dim)
+        return dim.pop()
+
+    def applyScale(self, exposure, scale=None):
+        """Apply scale to input exposure.
+
+        This implementation applies a flux scaling: the input exposure is
+        divided by the provided scale.
+
+        Parameters
+        ----------
+        exposure : `lsst.afw.image.Exposure`
+            Exposure to scale.
+        scale : `float` or `list` [`float`], optional
+            Constant scale to divide the exposure by.
+        """
+        if scale is not None:
+            mi = exposure.getMaskedImage()
+            if isinstance(scale, list):
+                for amp, ampScale in zip(exposure.getDetector(), scale):
+                    ampIm = mi[amp.getBBox()]
+                    ampIm /= ampScale
+            else:
+                mi /= scale
+
+    def combine(self, target, expList, stats):
+        """Combine multiple images.
+
+        Parameters
+        ----------
+        target : `lsst.afw.image.Exposure`
+            Output exposure to construct.
+        expList : `list` [`lsst.afw.image.Exposure`]
+            Input exposures to combine.
+        stats : `lsst.afw.math.StatisticsControl`
+            Control explaining how to combine the input images.
+        """
+        images = [img.getMaskedImage() for img in expList if img is not None]
+        afwMath.statisticsStack(target, images, afwMath.Property(self.config.combine), stats)
+
+    def combineHeaders(self, expList, calib, calibType="CALIB", scales=None):
+        """Combine input headers to determine the set of common headers,
+        supplemented by calibration inputs.
+
+        Parameters
+        ----------
+        expList : `list` of `lsst.afw.image.Exposure`
+            Input list of exposures to combine.
+        calib : `lsst.afw.image.Exposure`
+            Output calibration to construct headers for.
+        calibType: `str`, optional
+            OBSTYPE the output should claim.
+        scales: `list` of `float`, optional
+            Scale values applied to each input to record.
+
+        Returns
+        -------
+        header : `lsst.daf.base.PropertyList`
+            Constructed header.
+        """
+        # Header
+        header = calib.getMetadata()
+        header.set("OBSTYPE", calibType)
+
+        # Keywords we care about
+        comments = {"TIMESYS": "Time scale for all dates",
+                    "DATE-OBS": "Start date of earliest input observation",
+                    "MJD-OBS": "[d] Start MJD of earliest input observation",
+                    "DATE-END": "End date of oldest input observation",
+                    "MJD-END": "[d] End MJD of oldest input observation",
+                    "MJD-AVG": "[d] MJD midpoint of all input observations",
+                    "DATE-AVG": "Midpoint date of all input observations"}
+
+        # Creation date
+        now = time.localtime()
+        calibDate = time.strftime("%Y-%m-%d", now)
+        calibTime = time.strftime("%X %Z", now)
+        header.set("CALIB_CREATE_DATE", calibDate)
+        header.set("CALIB_CREATE_TIME", calibTime)
+
+        # Merge input headers
+        inputHeaders = [exp.getMetadata() for exp in expList if exp is not None]
+        merged = merge_headers(inputHeaders, mode='drop')
+        for k, v in merged.items():
+            if k not in header:
+                md = expList[0].getMetadata()
+                comment = md.getComment(k) if k in md else None
+                header.set(k, v, comment=comment)
+
+        # Construct list of visits
+        visitInfoList = [exp.getInfo().getVisitInfo() for exp in expList if exp is not None]
+        for i, visit in enumerate(visitInfoList):
+            if visit is None:
+                continue
+            header.set("CPP_INPUT_%d" % (i,), visit.getExposureId())
+            header.set("CPP_INPUT_DATE_%d" % (i,), str(visit.getDate()))
+            header.set("CPP_INPUT_EXPT_%d" % (i,), visit.getExposureTime())
+            if scales is not None:
+                header.set("CPP_INPUT_SCALE_%d" % (i,), scales[i])
+
+        # Not yet working: DM-22302
+        # Create an observation group so we can add some standard headers
+        # independent of the form in the input files.
+        # Use try block in case we are dealing with unexpected data headers
+        try:
+            group = ObservationGroup(visitInfoList, pedantic=False)
+        except Exception:
+            self.log.warn("Exception making an obs group for headers. Continuing.")
+            # Fall back to setting a DATE-OBS from the calibDate
+            dateCards = {"DATE-OBS": "{}T00:00:00.00".format(calibDate)}
+            comments["DATE-OBS"] = "Date of start of day of calibration midpoint"
+        else:
+            oldest, newest = group.extremes()
+            dateCards = dates_to_fits(oldest.datetime_begin, newest.datetime_end)
+
+        for k, v in dateCards.items():
+            header.set(k, v, comment=comments.get(k, None))
+
+        return header
+
+    def interpolateNans(self, exp):
+        """Interpolate over NANs in the combined image.
+
+        NANs can result from masked areas on the CCD.  We don't want them getting
+        into our science images, so we replace them with the median of the image.
+
+        Parameters
+        ----------
+        exp : `lsst.afw.image.Exposure`
+            Exp to check for NaNs.
+        """
+        array = exp.getImage().getArray()
+        bad = np.isnan(array)
+
+        median = np.median(array[np.logical_not(bad)])
+        count = np.sum(np.logical_not(bad))
+        array[bad] = median
+        if count > 0:
+            self.log.warn("Found %s NAN pixels", count)
+
+
+def VignetteExposure(exposure, polygon=None,
+                     doUpdateMask=True, maskPlane='BAD',
+                     doSetValue=False, vignetteValue=0.0,
+                     log=None):
+    """Apply vignetted polygon to image pixels.
+
+    Parameters
+    ----------
+    exposure : `lsst.afw.image.Exposure`
+        Image to be updated.
+    doUpdateMask : `bool`, optional
+        Update the exposure mask for vignetted area?
+    maskPlane : `str`, optional,
+        Mask plane to assign.
+    doSetValue : `bool`, optional
+        Set image value for vignetted area?
+    vignetteValue : `float`, optional
+        Value to assign.
+    log : `lsst.log.Log`, optional
+        Log to write to.
+
+    Raises
+    ------
+    RuntimeError
+        Raised if no valid polygon exists.
+    """
+    polygon = polygon if polygon else exposure.getInfo().getValidPolygon()
+    if not polygon:
+        raise RuntimeError("Could not find valid polygon!")
+    log = log if log else Log.getLogger(__name__.partition(".")[2])
+
+    fullyIlluminated = True
+    for corner in exposure.getBBox().getCorners():
+        if not polygon.contains(Point2D(corner)):
+            fullyIlluminated = False
+
+    log.info("Exposure is fully illuminated? %s", fullyIlluminated)
+
+    if not fullyIlluminated:
+        # Scan pixels.
+        mask = exposure.getMask()
+        numPixels = mask.getBBox().getArea()
+
+        xx, yy = np.meshgrid(np.arange(0, mask.getWidth(), dtype=int),
+                             np.arange(0, mask.getHeight(), dtype=int))
+
+        vignMask = np.array([not polygon.contains(Point2D(x, y)) for x, y in
+                             zip(xx.reshape(numPixels), yy.reshape(numPixels))])
+        vignMask = vignMask.reshape(mask.getHeight(), mask.getWidth())
+
+        if doUpdateMask:
+            bitMask = mask.getPlaneBitMask(maskPlane)
+            maskArray = mask.getArray()
+            maskArray[vignMask] |= bitMask
+        if doSetValue:
+            imageArray = exposure.getImage().getArray()
+            imageArray[vignMask] = vignetteValue
+        log.info("Exposure contains %d vignetted pixels.",
+                 np.count_nonzero(vignMask))

--- a/python/lsst/cp/pipe/cpDarkTask.py
+++ b/python/lsst/cp/pipe/cpDarkTask.py
@@ -1,0 +1,128 @@
+# This file is part of cp_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import math
+import numpy as np
+
+import lsst.pex.config as pexConfig
+import lsst.pipe.base as pipeBase
+import lsst.pipe.base.connectionTypes as cT
+from lsst.pipe.tasks.repair import RepairTask
+import lsst.meas.algorithms as measAlg
+import lsst.afw.geom as afwGeom
+
+
+__all__ = ["CpDarkTask", "CpDarkTaskConfig"]
+
+
+class CpDarkConnections(pipeBase.PipelineTaskConnections,
+                        dimensions=("instrument", "exposure", "detector")):
+    inputExp = cT.Input(
+        name="cpDarkISR",
+        doc="Input pre-processed exposures to combine.",
+        storageClass="ExposureF",
+        dimensions=("instrument", "exposure", "detector"),
+    )
+
+    outputExp = cT.Output(
+        name="cpDarkProc",
+        doc="Output combined proposed calibration.",
+        storageClass="ExposureF",
+        dimensions=("instrument", "exposure", "detector"),
+    )
+
+
+class CpDarkTaskConfig(pipeBase.PipelineTaskConfig,
+                       pipelineConnections=CpDarkConnections):
+    psfFwhm = pexConfig.Field(
+        dtype=float,
+        default=3.0,
+        doc="Repair PSF FWHM (pixels).",
+    )
+    psfSize = pexConfig.Field(
+        dtype=int,
+        default=21,
+        doc="Repair PSF size (pixels).",
+    )
+    crGrow = pexConfig.Field(
+        dtype=int,
+        default=2,
+        doc="Grow radius for CR (pixels).",
+    )
+    repair = pexConfig.ConfigurableField(
+        target=RepairTask,
+        doc="Repair task to use.",
+    )
+
+
+class CpDarkTask(pipeBase.PipelineTask,
+                 pipeBase.CmdLineTask):
+    """Combine pre-processed dark frames into a proposed master calibration.
+
+    """
+    ConfigClass = CpDarkTaskConfig
+    _DefaultName = "cpDark"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.makeSubtask("repair")
+
+    def run(self, inputExp):
+        """Preprocess input exposures prior to DARK combination.
+
+        This task detects and repairs cosmic rays strikes.
+
+        Parameters
+        ----------
+        inputExp : `lsst.afw.image.Exposure`
+            Pre-processed dark frame data to combine.
+
+        Returns
+        -------
+        outputExp : `lsst.afw.image.Exposure`
+            CR rejected, ISR processed Dark Frame."
+        """
+        psf = measAlg.SingleGaussianPsf(self.config.psfSize,
+                                        self.config.psfSize,
+                                        self.config.psfFwhm/(2*math.sqrt(2*math.log(2))))
+        inputExp.setPsf(psf)
+        scaleExp = inputExp.clone()
+        mi = scaleExp.getMaskedImage()
+
+        # DM-23680:
+        # Darktime scaling necessary for repair.run() to ID CRs correctly.
+        scale = inputExp.getInfo().getVisitInfo().getDarkTime()
+        if np.isfinite(scale) and scale != 0.0:
+            mi /= scale
+
+        self.repair.run(scaleExp, keepCRs=False)
+        if self.config.crGrow > 0:
+            crMask = inputExp.getMaskedImage().getMask().getPlaneBitMask("CR")
+            spans = afwGeom.SpanSet.fromMask(inputExp.mask, crMask)
+            spans = spans.dilated(self.config.crGrow)
+            spans.setMask(inputExp.mask, crMask)
+
+        # Undo scaling; as above, DM-23680.
+        if np.isfinite(scale) and scale != 0.0:
+            mi *= scale
+
+        return pipeBase.Struct(
+            outputExp=inputExp,
+        )

--- a/python/lsst/cp/pipe/cpFlatNormTask.py
+++ b/python/lsst/cp/pipe/cpFlatNormTask.py
@@ -152,7 +152,7 @@ class CpFlatNormalizationConnections(pipeBase.PipelineTaskConnections,
     outputScales = cT.Output(
         name="cpFlatNormScales",
         doc="Output combined proposed calibration.",
-        storageClass="StructuredDataDictYaml",
+        storageClass="StructuredDataDict",
         dimensions=("instrument", "physical_filter"),
     )
 

--- a/python/lsst/cp/pipe/cpFlatNormTask.py
+++ b/python/lsst/cp/pipe/cpFlatNormTask.py
@@ -293,15 +293,15 @@ class CpFlatNormalizationTask(pipeBase.PipelineTask,
             for detId, det in enumerate(detSet):
                 for amp in camera[detId]:
                     for expId, exp in enumerate(expSet):
-                        outputScales['expScale'][det][amp.getName()][exp] = expScales[expId]
-                outputScales['detScale'][det] = detScales[detId]
+                        outputScales['expScale'][det][amp.getName()][exp] = expScales[expId].tolist()
+                outputScales['detScale'][det] = detScales[detId].tolist()
         elif self.config.level == 'AMP':
             for detId, det in enumerate(detSet):
                 for ampIdx, amp in enumerate(camera[detId]):
                     for expId, exp in enumerate(expSet):
-                        outputScales['expScale'][det][amp.getName()][exp] = expScales[expId]
+                        outputScales['expScale'][det][amp.getName()][exp] = expScales[expId].tolist()
                     detAmpId = detId + ampIdx
-                    outputScales['detScale'][det][amp.getName()] = detScales[detAmpId]
+                    outputScales['detScale'][det][amp.getName()] = detScales[detAmpId].tolist()
 
         return pipeBase.Struct(
             outputScales=outputScales,

--- a/python/lsst/cp/pipe/cpFlatNormTask.py
+++ b/python/lsst/cp/pipe/cpFlatNormTask.py
@@ -1,0 +1,407 @@
+# This file is part of cp_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import numpy as np
+from collections import defaultdict
+
+import lsst.afw.math as afwMath
+import lsst.daf.base as dafBase
+import lsst.pex.config as pexConfig
+import lsst.pipe.base as pipeBase
+import lsst.pipe.base.connectionTypes as cT
+from lsst.cp.pipe.cpCombine import VignetteExposure
+
+__all__ = ["CpFlatMeasureTask", "CpFlatMeasureTaskConfig",
+           "CpFlatNormalizationTask", "CpFlatNormalizationTaskConfig"]
+
+
+class CpFlatMeasureConnections(pipeBase.PipelineTaskConnections,
+                               dimensions=("instrument", "exposure", "detector")):
+    inputExp = cT.Input(
+        name="postISRCCD",
+        doc="Input exposure to measure statistics from.",
+        storageClass="ExposureF",
+        dimensions=("instrument", "exposure", "detector"),
+    )
+    outputStats = cT.Output(
+        name="flatStats",
+        doc="Output statistics to write.",
+        storageClass="PropertyList",
+        dimensions=("instrument", "exposure", "detector"),
+    )
+
+
+class CpFlatMeasureTaskConfig(pipeBase.PipelineTaskConfig,
+                              pipelineConnections=CpFlatMeasureConnections):
+    maskNameList = pexConfig.ListField(
+        dtype=str,
+        doc="Mask list to exclude from statistics calculations.",
+        default=['DETECTED', 'BAD', 'NO_DATA'],
+    )
+    doVignette = pexConfig.Field(
+        dtype=bool,
+        doc="Mask vignetted regions?",
+        default=True,
+    )
+    numSigmaClip = pexConfig.Field(
+        dtype=float,
+        doc="Rejection threshold (sigma) for statistics clipping.",
+        default=3.0,
+    )
+    clipMaxIter = pexConfig.Field(
+        dtype=int,
+        doc="Max number of clipping iterations to apply.",
+        default=3,
+    )
+
+
+class CpFlatMeasureTask(pipeBase.PipelineTask,
+                        pipeBase.CmdLineTask):
+    """Apply extra masking and measure image statistics.
+    """
+    ConfigClass = CpFlatMeasureTaskConfig
+    _DefaultName = "cpFlatMeasure"
+
+    def run(self, inputExp):
+        """Mask ISR processed FLAT exposures to ensure consistent statistics.
+
+        Parameters
+        ----------
+        inputExp : `lsst.afw.image.Exposure`
+            Post-ISR processed exposure to measure.
+
+        Returns
+        -------
+        outputStats : `lsst.daf.base.PropertyList`
+            List containing the statistics.
+        """
+        if self.config.doVignette:
+            VignetteExposure(inputExp, doUpdateMask=True, maskPlane='BAD',
+                             doSetValue=False, log=self.log)
+        mask = inputExp.getMask()
+        maskVal = mask.getPlaneBitMask(self.config.maskNameList)
+        statsControl = afwMath.StatisticsControl(self.config.numSigmaClip,
+                                                 self.config.clipMaxIter,
+                                                 maskVal)
+        statsControl.setAndMask(maskVal)
+
+        outputStats = dafBase.PropertyList()
+
+        # Detector level:
+        stats = afwMath.makeStatistics(inputExp.getMaskedImage(),
+                                       afwMath.MEANCLIP | afwMath.STDEVCLIP | afwMath.NPOINT,
+                                       statsControl)
+        outputStats['DETECTOR_MEDIAN'] = stats.getValue(afwMath.MEANCLIP)
+        outputStats['DETECTOR_SIGMA'] = stats.getValue(afwMath.STDEVCLIP)
+        outputStats['DETECTOR_N'] = stats.getValue(afwMath.NPOINT)
+        self.log.info("Stats: median=%f sigma=%f n=%d",
+                      outputStats['DETECTOR_MEDIAN'],
+                      outputStats['DETECTOR_SIGMA'],
+                      outputStats['DETECTOR_N'])
+
+        # AMP LEVEL:
+        for ampIdx, amp in enumerate(inputExp.getDetector()):
+            ampName = amp.getName()
+            ampExp = inputExp.Factory(inputExp, amp.getBBox())
+            stats = afwMath.makeStatistics(ampExp.getMaskedImage(),
+                                           afwMath.MEANCLIP | afwMath.STDEVCLIP | afwMath.NPOINT,
+                                           statsControl)
+            outputStats[f'AMP_NAME_{ampIdx}'] = ampName
+            outputStats[f'AMP_MEDIAN_{ampIdx}'] = stats.getValue(afwMath.MEANCLIP)
+            outputStats[f'AMP_SIGMA_{ampIdx}'] = stats.getValue(afwMath.STDEVCLIP)
+            outputStats[f'AMP_N_{ampIdx}'] = stats.getValue(afwMath.NPOINT)
+
+        return pipeBase.Struct(
+            outputStats=outputStats
+        )
+
+
+class CpFlatNormalizationConnections(pipeBase.PipelineTaskConnections,
+                                     dimensions=("instrument", "physical_filter")):
+    inputMDs = cT.Input(
+        name="cpFlatProc_metadata",
+        doc="Input metadata for each visit/detector in input set.",
+        storageClass="PropertyList",
+        dimensions=("instrument", "physical_filter", "detector", "exposure"),
+        multiple=True,
+    )
+    camera = cT.PrerequisiteInput(
+        name="camera",
+        doc="Input camera to use for gain lookup.",
+        storageClass="Camera",
+        dimensions=("instrument", "calibration_label"),
+    )
+
+    outputScales = cT.Output(
+        name="cpFlatNormScales",
+        doc="Output combined proposed calibration.",
+        storageClass="StructuredDataDictYaml",
+        dimensions=("instrument", "physical_filter"),
+    )
+
+
+class CpFlatNormalizationTaskConfig(pipeBase.PipelineTaskConfig,
+                                    pipelineConnections=CpFlatNormalizationConnections):
+    level = pexConfig.ChoiceField(
+        dtype=str,
+        doc="Which level to apply normalizations.",
+        default='DETECTOR',
+        allowed={
+            'DETECTOR': "Correct using full detector statistics.",
+            'AMP': "Correct using individual amplifiers.",
+        },
+    )
+    scaleMaxIter = pexConfig.Field(
+        dtype=int,
+        doc="Max number of iterations to use in scale solver.",
+        default=10,
+    )
+
+
+class CpFlatNormalizationTask(pipeBase.PipelineTask,
+                              pipeBase.CmdLineTask):
+    """Rescale merged flat frames to remove unequal screen illumination.
+    """
+    ConfigClass = CpFlatNormalizationTaskConfig
+    _DefaultName = "cpFlatNorm"
+
+    def runQuantum(self, butlerQC, inputRefs, outputRefs):
+        inputs = butlerQC.get(inputRefs)
+
+        # Use the dimensions of the inputs for generating
+        # output scales.
+        dimensions = [exp.dataId.byName() for exp in inputRefs.inputMDs]
+        inputs['inputDims'] = dimensions
+
+        outputs = self.run(**inputs)
+        butlerQC.put(outputs, outputRefs)
+
+    def run(self, inputMDs, inputDims, camera):
+        """Normalize FLAT exposures to a consistent level.
+
+        Parameters
+        ----------
+        inputMDs : `list` [`lsst.daf.base.PropertyList`]
+            Amplifier-level metadata used to construct scales.
+        inputDims : `list` [`dict`]
+            List of dictionaries of input data dimensions/values.
+            Each list entry should contain:
+
+            ``"exposure"``
+                exposure id value (`int`)
+            ``"detector"``
+                detector id value (`int`)
+
+        Returns
+        -------
+        outputScales : `dict` [`dict` [`dict` [`float`]]]
+            Dictionary of scales, indexed by detector (`int`),
+            amplifier (`int`), and exposure (`int`).
+
+        Raises
+        ------
+        KeyError
+            Raised if the input dimensions do not contain detector and
+            exposure, or if the metadata does not contain the expected
+            statistic entry.
+        """
+        expSet = sorted(set([d['exposure'] for d in inputDims]))
+        detSet = sorted(set([d['detector'] for d in inputDims]))
+
+        expMap = {exposureId: idx for idx, exposureId in enumerate(expSet)}
+        detMap = {detectorId: idx for idx, detectorId in enumerate(detSet)}
+
+        nExp = len(expSet)
+        nDet = len(detSet)
+        if self.config.level == 'DETECTOR':
+            bgMatrix = np.zeros((nDet, nExp))
+            bgCounts = np.ones((nDet, nExp))
+        elif self.config.level == 'AMP':
+            nAmp = len(camera[0])
+            bgMatrix = np.zeros((nDet * nAmp, nExp))
+            bgCounts = np.ones((nDet * nAmp, nExp))
+
+        for inMetadata, inDimensions in zip(inputMDs, inputDims):
+            try:
+                exposureId = inDimensions['exposure']
+                detectorId = inDimensions['detector']
+            except Exception as e:
+                raise KeyError("Cannot find expected dimensions in %s" % (inDimensions, )) from e
+
+            if self.config.level == 'DETECTOR':
+                detId = detMap[detectorId]
+                expId = expMap[exposureId]
+                try:
+                    value = inMetadata.get('DETECTOR_MEDIAN')
+                    count = inMetadata.get('DETECTOR_N')
+                except Exception as e:
+                    raise KeyError("Cannot read expected metadata string.") from e
+
+                if np.isfinite(value):
+                    bgMatrix[detId][expId] = value
+                    bgCounts[detId][expId] = count
+                else:
+                    bgMatrix[detId][expId] = np.nan
+                    bgCounts[detId][expId] = 1
+
+            elif self.config.level == 'AMP':
+                detector = camera[detectorId]
+                nAmp = len(detector)
+
+                detId = detMap[detectorId] * nAmp
+                expId = expMap[exposureId]
+
+                for ampIdx, amp in enumerate(detector):
+                    try:
+                        value = inMetadata.get(f'AMP_MEDIAN_{ampIdx}')
+                        count = inMetadata.get(f'AMP_N_{ampIdx}')
+                    except Exception as e:
+                        raise KeyError("cannot read expected metadata string.") from e
+
+                    detAmpId = detId + ampIdx
+                    if np.isfinite(value):
+                        bgMatrix[detAmpId][expId] = value
+                        bgCounts[detAmpId][expId] = count
+                    else:
+                        bgMatrix[detAmpId][expId] = np.nan
+                        bgMatrix[detAmpId][expId] = 1
+
+        scaleResult = self.measureScales(bgMatrix, bgCounts, iterations=self.config.scaleMaxIter)
+        expScales = scaleResult.expScales
+        detScales = scaleResult.detScales
+
+        outputScales = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(float))))
+
+        if self.config.level == 'DETECTOR':
+            for detId, det in enumerate(detSet):
+                for amp in camera[detId]:
+                    for expId, exp in enumerate(expSet):
+                        outputScales['expScale'][det][amp.getName()][exp] = expScales[expId]
+                outputScales['detScale'][det] = detScales[detId]
+        elif self.config.level == 'AMP':
+            for detId, det in enumerate(detSet):
+                for ampIdx, amp in enumerate(camera[detId]):
+                    for expId, exp in enumerate(expSet):
+                        outputScales['expScale'][det][amp.getName()][exp] = expScales[expId]
+                    detAmpId = detId + ampIdx
+                    outputScales['detScale'][det][amp.getName()] = detScales[detAmpId]
+
+        return pipeBase.Struct(
+            outputScales=outputScales,
+        )
+
+    def measureScales(self, bgMatrix, bgCounts=None, iterations=10):
+        """Convert backgrounds to exposure and detector components.
+
+        Parameters
+        ----------
+        bgMatrix : `np.ndarray`, (nDetectors, nExposures)
+            Input backgrounds indexed by exposure (axis=0) and
+            detector (axis=1).
+        bgCounts : `np.ndarray`, (nDetectors, nExposures), optional
+            Input pixel counts used to in measuring bgMatrix, indexed
+            identically.
+        iterations : `int`, optional
+            Number of iterations to use in decomposition.
+
+        Returns
+        -------
+        scaleResult : `lsst.pipe.base.Struct`
+            Result struct containing fields:
+
+            ``vectorE``
+                Output E vector of exposure level scalings
+                (`np.array`, (nExposures)).
+            ``vectorG``
+                Output G vector of detector level scalings
+                (`np.array`, (nExposures)).
+            ``bgModel``
+                Expected model bgMatrix values, calculated from E and G
+                (`np.ndarray`, (nDetectors, nExposures)).
+
+        Notes
+        -----
+
+        The set of background measurements B[exposure, detector] of
+        flat frame data should be defined by a "Cartesian" product of
+        two vectors, E[exposure] and G[detector].  The E vector
+        represents the total flux incident on the focal plane.  In a
+        perfect camera, this is simply the sum along the columns of B
+        (np.sum(B, axis=0)).
+
+        However, this simple model ignores differences in detector
+        gains, the vignetting of the detectors, and the illumination
+        pattern of the source lamp.  The G vector describes these
+        detector dependent differences, which should be identical over
+        different exposures.  For a perfect lamp of unit total
+        intensity, this is simply the sum along the rows of B
+        (np.sum(B, axis=1)).  This algorithm divides G by the total
+        flux level, to provide the relative (not absolute) scales
+        between detectors.
+
+        The algorithm here, from pipe_drivers/constructCalibs.py and
+        from there from Eugene Magnier/PanSTARRS [1]_, attempts to
+        iteratively solve this decomposition from initial "perfect" E
+        and G vectors.  The operation is performed in log space to
+        reduce the multiply and divides to linear additions and
+        subtractions.
+
+        References
+        ----------
+        .. [1] https://svn.pan-starrs.ifa.hawaii.edu/trac/ipp/browser/trunk/psModules/src/detrend/pmFlatNormalize.c  # noqa: E501
+
+        """
+        numExps = bgMatrix.shape[1]
+        numChips = bgMatrix.shape[0]
+        if bgCounts is None:
+            bgCounts = np.ones_like(bgMatrix)
+
+        logMeas = np.log(bgMatrix)
+        logMeas = np.ma.masked_array(logMeas, ~np.isfinite(logMeas))
+        logG = np.zeros(numChips)
+        logE = np.array([np.average(logMeas[:, iexp] - logG,
+                                    weights=bgCounts[:, iexp]) for iexp in range(numExps)])
+
+        for iter in range(iterations):
+            logG = np.array([np.average(logMeas[ichip, :] - logE,
+                                        weights=bgCounts[ichip, :]) for ichip in range(numChips)])
+
+            bad = np.isnan(logG)
+            if np.any(bad):
+                logG[bad] = logG[~bad].mean()
+
+            logE = np.array([np.average(logMeas[:, iexp] - logG,
+                                        weights=bgCounts[:, iexp]) for iexp in range(numExps)])
+            fluxLevel = np.average(np.exp(logG), weights=np.sum(bgCounts, axis=1))
+
+            logG -= np.log(fluxLevel)
+            self.log.debug(f"ITER {iter}: Flux: {fluxLevel}")
+            self.log.debug(f"Exps: {np.exp(logE)}")
+            self.log.debug(f"{np.mean(logG)}")
+
+        logE = np.array([np.average(logMeas[:, iexp] - logG,
+                                    weights=bgCounts[:, iexp]) for iexp in range(numExps)])
+
+        bgModel = np.exp(logE[np.newaxis, :] - logG[:, np.newaxis])
+        return pipeBase.Struct(
+            expScales=np.exp(logE),
+            detScales=np.exp(logG),
+            bgModel=bgModel,
+        )

--- a/python/lsst/cp/pipe/cpFringeTask.py
+++ b/python/lsst/cp/pipe/cpFringeTask.py
@@ -1,0 +1,118 @@
+# This file is part of cp_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import lsst.pex.config as pexConfig
+import lsst.pipe.base as pipeBase
+import lsst.pipe.base.connectionTypes as cT
+import lsst.cp.pipe.cpCombine as cpCombine
+import lsst.meas.algorithms as measAlg
+import lsst.afw.detection as afwDet
+
+
+__all__ = ["CpFringeTask", "CpFringeTaskConfig"]
+
+
+class CpFringeConnections(pipeBase.PipelineTaskConnections,
+                          dimensions=("instrument", "exposure", "detector")):
+    inputExp = cT.Input(
+        name="cpFringeISR",
+        doc="Input pre-processed exposures to combine.",
+        storageClass="ExposureF",
+        dimensions=("instrument", "exposure", "detector"),
+    )
+
+    outputExp = cT.Output(
+        name="cpFringeProc",
+        doc="Output combined proposed calibration.",
+        storageClass="ExposureF",
+        dimensions=("instrument", "exposure", "detector"),
+    )
+
+
+class CpFringeTaskConfig(pipeBase.PipelineTaskConfig,
+                         pipelineConnections=CpFringeConnections):
+    stats = pexConfig.ConfigurableField(
+        target=cpCombine.CalibStatsTask,
+        doc="Statistics task to use.",
+    )
+    subtractBackground = pexConfig.ConfigurableField(
+        target=measAlg.SubtractBackgroundTask,
+        doc="Background configuration",
+    )
+    detection = pexConfig.ConfigurableField(
+        target=measAlg.SourceDetectionTask,
+        doc="Detection configuration",
+    )
+    detectSigma = pexConfig.Field(
+        dtype=float,
+        default=1.0,
+        doc="Detection psf gaussian sigma.",
+    )
+
+    def setDefaults(self):
+        self.detection.reEstimateBackground = False
+
+
+class CpFringeTask(pipeBase.PipelineTask,
+                   pipeBase.CmdLineTask):
+    """Combine pre-processed fringe frames into a proposed master calibration.
+    """
+    ConfigClass = CpFringeTaskConfig
+    _DefaultName = "cpFringe"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.makeSubtask("stats")
+        self.makeSubtask("subtractBackground")
+        self.makeSubtask("detection")
+
+    def run(self, inputExp):
+        """Preprocess input exposures prior to FRINGE combination.
+
+        This task scales and renormalizes the input frame based on the
+        image background, and then masks all pixels above the
+        detection threshold.
+
+        Parameters
+        ----------
+        inputExp : `lsst.afw.image.Exposure`
+            Pre-processed fringe frame data to combine.
+
+        Returns
+        -------
+        outputExp : `lsst.afw.image.Exposure`
+            Fringe pre-processed frame.
+
+        """
+        bg = self.stats.run(inputExp)
+        self.subtractBackground.run(inputExp)
+        mi = inputExp.getMaskedImage()
+        mi /= bg
+
+        fpSets = self.detection.detectFootprints(inputExp, sigma=self.config.detectSigma)
+        mask = mi.getMask()
+        detected = 1 << mask.addMaskPlane("DETECTED")
+        for fpSet in (fpSets.positive, fpSets.negative):
+            if fpSet is not None:
+                afwDet.setMaskFromFootprintList(mask, fpSet.getFootprints(), detected)
+
+        return pipeBase.Struct(
+            outputExp=inputExp,
+        )

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -1,3 +1,3 @@
 # -*- python -*-
 from lsst.sconsUtils import scripts
-scripts.BasicSConscript.tests()
+scripts.BasicSConscript.tests(pyList=[])

--- a/ups/cp_pipe.table
+++ b/ups/cp_pipe.table
@@ -11,6 +11,8 @@ setupRequired(log)
 setupRequired(ip_isr)
 setupRequired(afw)
 setupRequired(meas_algorithms)
+setupRequired(pipe_drivers)
+setupRequired(pipe_tasks)
 
 # The following is boilerplate for all packages.
 # See Tech Note DMTN-001 for details on LSST_LIBRARY_PATH


### PR DESCRIPTION
Tickets/dm 21212

This ticket converts the existing pipe_drivers constructCalibs.py tasks to Gen3, and uses pipelines to handle multiprocessing, configuration, and task handling.