### PR TITLE
DM-23651: ap_pipe calls some deprecated things

### DIFF
--- a/python/lsst/cp/pipe/defects.py
+++ b/python/lsst/cp/pipe/defects.py
@@ -70,14 +70,14 @@ class FindDefectsTaskConfig(pexConfig.Config):
         dtype=str,
         doc=("isr operations that must NOT be performed for valid results when using flats."
              " Raises if any of these are True"),
-        default=['doAddDistortionModel', 'doBrighterFatter', 'doUseOpticsTransmission',
+        default=['doBrighterFatter', 'doUseOpticsTransmission',
                  'doUseFilterTransmission', 'doUseSensorTransmission', 'doUseAtmosphereTransmission']
     )
     isrForbiddenStepsDarks = pexConfig.ListField(
         dtype=str,
         doc=("isr operations that must NOT be performed for valid results when using darks."
              " Raises if any of these are True"),
-        default=['doAddDistortionModel', 'doBrighterFatter', 'doUseOpticsTransmission',
+        default=['doBrighterFatter', 'doUseOpticsTransmission',
                  'doUseFilterTransmission', 'doUseSensorTransmission', 'doUseAtmosphereTransmission']
     )
     isrDesirableSteps = pexConfig.ListField(

--- a/python/lsst/cp/pipe/makeBrighterFatterKernel.py
+++ b/python/lsst/cp/pipe/makeBrighterFatterKernel.py
@@ -64,7 +64,7 @@ class MakeBrighterFatterKernelTaskConfig(pexConfig.Config):
     isrForbiddenSteps = pexConfig.ListField(
         dtype=str,
         doc="isr operations that must NOT be performed for valid results. Raises if any of these are True",
-        default=['doFlat', 'doFringe', 'doAddDistortionModel', 'doBrighterFatter', 'doUseOpticsTransmission',
+        default=['doFlat', 'doFringe', 'doBrighterFatter', 'doUseOpticsTransmission',
                  'doUseFilterTransmission', 'doUseSensorTransmission', 'doUseAtmosphereTransmission']
     )
     isrDesirableSteps = pexConfig.ListField(

--- a/python/lsst/cp/pipe/ptc.py
+++ b/python/lsst/cp/pipe/ptc.py
@@ -59,7 +59,7 @@ class MeasurePhotonTransferCurveTaskConfig(pexConfig.Config):
     isrForbiddenSteps = pexConfig.ListField(
         dtype=str,
         doc="isr operations that must NOT be performed for valid results. Raises if any of these are True",
-        default=['doFlat', 'doFringe', 'doAddDistortionModel', 'doBrighterFatter', 'doUseOpticsTransmission',
+        default=['doFlat', 'doFringe', 'doBrighterFatter', 'doUseOpticsTransmission',
                  'doUseFilterTransmission', 'doUseSensorTransmission', 'doUseAtmosphereTransmission']
     )
     isrDesirableSteps = pexConfig.ListField(

--- a/tests/test_defects.py
+++ b/tests/test_defects.py
@@ -44,7 +44,6 @@ class FindDefectsTaskTestCase(lsst.utils.tests.TestCase):
 
         for config in [self.defaultConfig.isrForDarks, self.defaultConfig.isrForFlats]:
             config.doCrosstalk = False
-            config.doAddDistortionModel = False
             config.doUseOpticsTransmission = False
             config.doUseFilterTransmission = False
             config.doUseSensorTransmission = False

--- a/tests/test_ptc.py
+++ b/tests/test_ptc.py
@@ -45,7 +45,6 @@ class MeasurePhotonTransferCurveTaskTestCase(lsst.utils.tests.TestCase):
         self.defaultConfig.isr.doFlat = False
         self.defaultConfig.isr.doFringe = False
         self.defaultConfig.isr.doCrosstalk = False
-        self.defaultConfig.isr.doAddDistortionModel = False
         self.defaultConfig.isr.doUseOpticsTransmission = False
         self.defaultConfig.isr.doUseFilterTransmission = False
         self.defaultConfig.isr.doUseSensorTransmission = False


### PR DESCRIPTION
This PR removes all references to the `IsrConfig.doAddDistortionModel` field, which is no longer  used by `IsrTask`.