### PR TITLE
 DM-24703: Make linearity a subclass of lsst.ip.isr.IsrCalib

### DIFF
--- a/python/lsst/cp/pipe/__init__.py
+++ b/python/lsst/cp/pipe/__init__.py
@@ -34,3 +34,4 @@ from .cpCombine import *
 from .cpCertify import *
 from .plotPtc import *
 from .measureCrosstalk import *
+from .linearity import *

--- a/python/lsst/cp/pipe/linearity.py
+++ b/python/lsst/cp/pipe/linearity.py
@@ -1,0 +1,235 @@
+# This file is part of cp_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import numpy as np
+
+import lsst.pipe.base as pipeBase
+import lsst.pipe.base.connectionTypes as cT
+import lsst.pex.config as pexConfig
+
+from lsstDebug import getDebugFrame
+from lsst.ip.isr import (Linearizer, IsrProvenance)
+
+from .utils import (fitLeastSq, funcPolynomial)
+
+
+__all__ = ["LinearitySolveTask", "LinearitySolveConfig"]
+
+
+class LinearitySolveConnections(pipeBase.PipelineTaskConnections,
+                                dimensions=("instrument", "detector")):
+
+    inputPtc = cT.Input(
+        name="inputPtc",
+        doc="Input PTC dataset.",
+        storageClass="StructuredDataDict",
+        dimensions=("instrument", "detector"),
+        multiple=False,
+    )
+    camera = cT.Input(
+        name="camera",
+        doc="Camera Geometry definition.",
+        storageClass="Camera",
+        dimensions=("instrument", ),
+    )
+    outputLinearizer = cT.Output(
+        name="linearity",
+        doc="Output linearity measurements.",
+        storageClass="Linearizer",
+        dimensions=("instrument", "detector"),
+    )
+
+
+class LinearitySolveConfig(pipeBase.PipelineTaskConfig,
+                           pipelineConnections=LinearitySolveConnections):
+    """Configuration for solving the linearity from PTC dataset.
+    """
+    linearityType = pexConfig.ChoiceField(
+        dtype=str,
+        doc="Type of linearizer to construct.",
+        default="Polynomial",
+        allowed={
+            "LookupTable": "Create a lookup table solution.",
+            "Polynomial": "Create an arbitrary polynomial solution.",
+            "Squared": "Create a single order squared solution.",
+            "None": "Create a dummy solution.",
+        }
+    )
+    polynomialOrder = pexConfig.Field(
+        dtype=int,
+        doc="Degree of polynomial to fit.",
+        default=3,
+    )
+    maxLookupTableAdu = pexConfig.Field(
+        dtype=int,
+        doc="Maximum DN value for a LookupTable linearizer.",
+        default=2**18,
+    )
+
+
+class LinearitySolveTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
+    """Fit the linearity from the PTC dataset.
+    """
+    ConfigClass = LinearitySolveConfig
+    _DefaultName = 'cpLinearitySolve'
+
+    def runQuantum(self, butlerQC, inputRefs, outputRefs):
+        """Ensure that the input and output dimensions are passed along.
+
+        Parameters
+        ----------
+        butlerQC : `lsst.daf.butler.butlerQuantumContext.ButlerQuantumContext`
+            Butler to operate on.
+        inputRefs : `lsst.pipe.base.connections.InputQuantizedConnection`
+            Input data refs to load.
+        ouptutRefs : `lsst.pipe.base.connections.OutputQuantizedConnection`
+            Output data refs to persist.
+        """
+        inputs = butlerQC.get(inputRefs)
+
+        # Use the dimensions to set calib/provenance information.
+        inputs['inputDims'] = [exp.dataId.byName() for exp in inputRefs.inputPtc]
+
+        outputs = self.run(**inputs)
+        butlerQC.put(outputs, outputRefs)
+
+    def run(self, inputPtc, camera=None, inputDims=None):
+        """Fit non-linearity to PTC data, returning the correct Linearizer
+        object.
+
+        Parameters
+        ----------
+        inputPtc : `lsst.cp.pipe.PtcDataset`
+            Pre-measured PTC dataset.
+        camera : `lsst.afw.cameraGeom.Camera`, optional
+            Camera geometry.
+        inputDims : `lsst.daf.butler.DataCoordinate` or `dict`, optional
+            DataIds to use to populate the output calibration.
+
+        Returns
+        -------
+        results : `lsst.pipe.base.Struct`
+            The results struct containing:
+
+            ``outputLinearizer`` : `lsst.ip.isr.Linearizer`
+                Final linearizer calibration.
+            ``outputProvenance`` : `lsst.ip.isr.IsrProvenance`
+                Provenance data for the new calibration.
+        """
+        if camera:
+            detector = camera[inputDims['detector']]
+
+        if self.config.linearityType == 'LookupTable':
+            table = np.zeros((len(detector), self.config.maxLookupTableAdu), dtype=np.float32)
+            tableIndex = 0
+        else:
+            table = None
+            tableIndex = None  # This will fail if we increment it.
+
+        # Initialize the linearizer.
+        linearizer = Linearizer(detector=detector, table=table, log=self.log)
+
+        for i, amp in enumerate(detector):
+            ampName = amp.getName()
+            if (len(inputPtc.visitMask[ampName]) == 0):
+                self.log.warn(f"Mask not found for {ampName} in non-linearity fit. Using all points.")
+                mask = np.repeat(True, len(inputPtc.rawExpTimes[ampName]))
+            else:
+                mask = inputPtc.visitMask[ampName]
+
+            timeVector = np.array(inputPtc.rawExpTimes[ampName])[mask]
+            meanVector = np.array(inputPtc.rawMeans[ampName])[mask]
+
+            if self.config.linearityType in ['Polynomial', 'Squared', 'LookupTable']:
+                polyFit = np.zeros(self.config.polynomialOrder + 1)
+                polyFit[1] = 1.0
+                polyFit, polyFitErr, chiSq = fitLeastSq(polyFit, timeVector, meanVector, funcPolynomial)
+
+                # Truncate the polynomial fit
+                k1 = polyFit[1]
+                linearityFit = [-coeff/(k1**order) for order, coeff in enumerate(polyFit)]
+                significant = np.where(np.abs(linearityFit) > 1e-10, True, False)
+                self.log.info(f"Significant polynomial fits: {significant}")
+
+                if self.config.linearityType == 'Squared':
+                    linearityFit = [linearityFit[2]]
+                elif self.config.linearityType == 'LookupTable':
+                    # Use linear part to get time at wich signal is maxAduForLookupTableLinearizer DN
+                    tMax = (self.config.maxLookupTableAdu - polyFit[0])/polyFit[1]
+                    timeRange = np.linspace(0, tMax, self.config.maxLookupTableAdu)
+                    signalIdeal = polyFit[0] + polyFit[1]*timeRange
+                    signalUncorrected = funcPolynomial(polyFit, timeRange)
+                    lookupTableRow = signalIdeal - signalUncorrected  # LinearizerLookupTable has corrections
+
+                    linearizer.tableData[tableIndex, :] = lookupTableRow
+                    linearityFit = [tableIndex, 0]
+                    tableIndex += 1
+            else:
+                polyFit = [0.0]
+                polyFitErr = [0.0]
+                chiSq = np.nan
+                linearityFit = [0.0]
+
+            linearizer.linearityType[ampName] = 'self.config.linearityType'
+            linearizer.linearityCoeffs[ampName] = linearityFit
+            linearizer.linearityBBox[ampName] = amp.getBBox()
+            linearizer.fitParams[ampName] = polyFit
+            linearizer.fitParamsErr[ampName] = polyFitErr
+            linearizer.fitChiSq[ampName] = chiSq
+            self.debugFit('solution', timeVector, meanVector, linearizer, ampName)
+
+        linearizer.validate()
+        linearizer.updateMetadata(setDate=True)
+        provenance = IsrProvenance(calibType='linearizer')
+
+        return pipeBase.Struct(
+            outputLinearizer=linearizer,
+            outputProvenance=provenance,
+        )
+
+    def debugFit(self, stepname, timeVector, meanVector, linearizer, ampName):
+        """
+        """
+        frame = getDebugFrame(self._display, stepname)
+        if frame:
+            import matplotlib.pyplot as plot
+            figure = plot.figure(1)
+            figure.clear()
+
+            axes = figure.add_axes((min(timeVector), min(meanVector),
+                                    max(timeVector), max(meanVector)))
+            axes.plot(timeVector, meanVector, 'k+')
+
+            axes.plot(timeVector,
+                      np.polynomial.polynomial.polyval(linearizer.fitParams[ampName],
+                                                       timeVector), 'r')
+            plot.xlabel("Exposure Time")
+            plot.ylabel("Mean Flux")
+            plot.title(f"Linearity {ampName} {linearizer.linearityType[ampName]}"
+                       f" chi={linearizer.fitChiSq[ampName]}")
+            figure.show()
+
+            prompt = "Press enter to continue: "
+            while True:
+                ans = input(prompt).lower()
+                if ans in ("", "c",):
+                    break
+            plot.close()

--- a/python/lsst/cp/pipe/ptc.py
+++ b/python/lsst/cp/pipe/ptc.py
@@ -167,22 +167,6 @@ class MeasurePhotonTransferCurveTaskConfig(pexConfig.Config):
     )
 
 
-# @dataclass
-# class LinearityResidualsAndLinearizersDataset:
-#     """A simple class to hold the output from the
-#        `calculateLinearityResidualAndLinearizers` function.
-#     """
-#     # Normalized coefficients for polynomial NL correction
-#     polynomialLinearizerCoefficients: list
-#     # Normalized coefficient for quadratic polynomial NL correction (c0)
-#     quadraticPolynomialLinearizerCoefficient: float
-#     # LUT array row for the amplifier at hand
-#     linearizerTableRow: list
-#     meanSignalVsTimePolyFitPars: list
-#     meanSignalVsTimePolyFitParsErr: list
-#     meanSignalVsTimePolyFitReducedChiSq: float
-
-
 class PhotonTransferCurveDataset:
     """A simple class to hold the output data from the PTC task.
 

--- a/python/lsst/cp/pipe/ptc.py
+++ b/python/lsst/cp/pipe/ptc.py
@@ -28,7 +28,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 from sqlite3 import OperationalError
 from collections import Counter
-from dataclasses import dataclass
 
 import lsst.afw.math as afwMath
 import lsst.pex.config as pexConfig
@@ -37,10 +36,10 @@ from .utils import (NonexistentDatasetTaskDataIdContainer, PairedVisitListTaskRu
                     checkExpLengthEqual, fitLeastSq, fitBootstrap, funcPolynomial, funcAstier)
 from scipy.optimize import least_squares
 
-from lsst.ip.isr.linearize import Linearizer
 import datetime
 
 from .astierCovPtcUtils import (fftSize, CovFft, computeCovDirect, fitData)
+from .linearity import LinearitySolveTask
 
 
 class MeasurePhotonTransferCurveTaskConfig(pexConfig.Config):
@@ -85,27 +84,17 @@ class MeasurePhotonTransferCurveTaskConfig(pexConfig.Config):
         doc="Degree of polynomial to fit the PTC, when 'ptcFitType'=POLYNOMIAL.",
         default=3,
     )
+    linearity = pexConfig.ConfigurableField(
+        target=LinearitySolveTask,
+        doc="Task to solve the linearity."
+    )
+
     doCreateLinearizer = pexConfig.Field(
         dtype=bool,
         doc="Calculate non-linearity and persist linearizer?",
         default=False,
     )
-    linearizerType = pexConfig.ChoiceField(
-        dtype=str,
-        doc="Linearizer type, if doCreateLinearizer=True",
-        default="LINEARIZEPOLYNOMIAL",
-        allowed={
-            "LINEARIZEPOLYNOMIAL": "n-degree polynomial (use 'polynomialFitDegreeNonLinearity' to set 'n').",
-            "LINEARIZESQUARED": "c0 quadratic coefficient derived from coefficients of polynomiual fit",
-            "LOOKUPTABLE": "Loouk table formed from linear part of polynomial fit."
-        }
-    )
-    polynomialFitDegreeNonLinearity = pexConfig.Field(
-        dtype=int,
-        doc="If doCreateLinearizer, degree of polynomial to fit the meanSignal vs exposureTime" +
-            " curve to produce the table for LinearizeLookupTable.",
-        default=3,
-    )
+
     binSize = pexConfig.Field(
         dtype=int,
         doc="Bin the image by this factor in both dimensions.",
@@ -171,11 +160,6 @@ class MeasurePhotonTransferCurveTaskConfig(pexConfig.Config):
         doc="Use bootstrap for the PTC fit parameters and errors?.",
         default=False,
     )
-    maxAduForLookupTableLinearizer = pexConfig.Field(
-        dtype=int,
-        doc="Maximum DN value for the LookupTable linearizer.",
-        default=2**18,
-    )
     instrumentName = pexConfig.Field(
         dtype=str,
         doc="Instrument name.",
@@ -183,20 +167,20 @@ class MeasurePhotonTransferCurveTaskConfig(pexConfig.Config):
     )
 
 
-@dataclass
-class LinearityResidualsAndLinearizersDataset:
-    """A simple class to hold the output from the
-       `calculateLinearityResidualAndLinearizers` function.
-    """
-    # Normalized coefficients for polynomial NL correction
-    polynomialLinearizerCoefficients: list
-    # Normalized coefficient for quadratic polynomial NL correction (c0)
-    quadraticPolynomialLinearizerCoefficient: float
-    # LUT array row for the amplifier at hand
-    linearizerTableRow: list
-    meanSignalVsTimePolyFitPars: list
-    meanSignalVsTimePolyFitParsErr: list
-    meanSignalVsTimePolyFitReducedChiSq: float
+# @dataclass
+# class LinearityResidualsAndLinearizersDataset:
+#     """A simple class to hold the output from the
+#        `calculateLinearityResidualAndLinearizers` function.
+#     """
+#     # Normalized coefficients for polynomial NL correction
+#     polynomialLinearizerCoefficients: list
+#     # Normalized coefficient for quadratic polynomial NL correction (c0)
+#     quadraticPolynomialLinearizerCoefficient: float
+#     # LUT array row for the amplifier at hand
+#     linearizerTableRow: list
+#     meanSignalVsTimePolyFitPars: list
+#     meanSignalVsTimePolyFitParsErr: list
+#     meanSignalVsTimePolyFitReducedChiSq: float
 
 
 class PhotonTransferCurveDataset:
@@ -347,6 +331,7 @@ class MeasurePhotonTransferCurveTask(pipeBase.CmdLineTask):
 
     def __init__(self, *args, **kwargs):
         pipeBase.CmdLineTask.__init__(self, *args, **kwargs)
+        self.makeSubtask("linearity")
         plt.interactive(False)  # stop windows popping up when plotting. When headless, use 'agg' backend too
         self.config.validate()
         self.config.freeze()
@@ -381,7 +366,8 @@ class MeasurePhotonTransferCurveTask(pipeBase.CmdLineTask):
 
         # setup necessary objects
         detNum = dataRef.dataId[self.config.ccdKey]
-        detector = dataRef.get('camera')[dataRef.dataId[self.config.ccdKey]]
+        camera = dataRef.get('camera')
+        detector = camera[dataRef.dataId[self.config.ccdKey]]
         # expand some missing fields that we need for lsstCam.  This is a work-around
         # for Gen2 problems that I (RHL) don't feel like solving.  The calibs pipelines
         # (which inherit from CalibTask) use addMissingKeys() to do basically the same thing
@@ -458,40 +444,23 @@ class MeasurePhotonTransferCurveTask(pipeBase.CmdLineTask):
 
         # Fit a poynomial to calculate non-linearity and persist linearizer.
         if self.config.doCreateLinearizer:
-            numberAmps = len(amps)
-            numberAduValues = self.config.maxAduForLookupTableLinearizer
-            lookupTableArray = np.zeros((numberAmps, numberAduValues), dtype=np.float32)
-
             # Fit (non)linearity of signal vs time curve.
             # Fill up PhotonTransferCurveDataset object.
             # Fill up array for LUT linearizer (tableArray).
             # Produce coefficients for Polynomial ans Squared linearizers.
             # Build linearizer objects.
-            linearizer = self.fitNonLinearityAndBuildLinearizers(datasetPtc, detector,
-                                                                 tableArray=lookupTableArray,
-                                                                 log=self.log)
-
-            if self.config.linearizerType == "LINEARIZEPOLYNOMIAL":
-                linDataType = 'linearizePolynomial'
-                linMsg = "polynomial (coefficients for a polynomial correction)."
-            elif self.config.linearizerType == "LINEARIZESQUARED":
-                linDataType = 'linearizePolynomial'
-                linMsg = "squared (c0, derived from k_i coefficients of a polynomial fit)."
-            elif self.config.linearizerType == "LOOKUPTABLE":
-                linDataType = 'linearizePolynomial'
-                linMsg = "lookup table (linear component of polynomial fit)."
-            else:
-                raise RuntimeError("Invalid config.linearizerType {selg.config.linearizerType}. "
-                                   "Supported: 'LOOKUPTABLE', 'LINEARIZESQUARED', or 'LINEARIZEPOLYNOMIAL'")
+            dimensions = {'camera': camera.getName(), 'detector': detector.getId()}
+            linearityResults = self.linearity.run(datasetPtc, camera, dimensions)
+            linearizer = linearityResults.outputLinearizer
 
             butler = dataRef.getButler()
-            self.log.info(f"Writing linearizer: \n {linMsg}")
+            self.log.info("Writing linearizer:")
 
             detName = detector.getName()
             now = datetime.datetime.utcnow()
             calibDate = now.strftime("%Y-%m-%d")
 
-            butler.put(linearizer, datasetType=linDataType, dataId={'detector': detNum,
+            butler.put(linearizer, datasetType='Linearizer', dataId={'detector': detNum,
                        'detectorName': detName, 'calibDate': calibDate})
 
         self.log.info(f"Writing PTC data to {dataRef.getUri(write=True)}")
@@ -797,286 +766,6 @@ class MeasurePhotonTransferCurveTask(pipeBase.CmdLineTask):
         cov = p - s1*s2
 
         return cov, nPix
-
-    def fitNonLinearityAndBuildLinearizers(self, datasetPtc, detector, tableArray=None, log=None):
-        """Fit non-linearity function and build linearizer objects.
-
-        Parameters
-        ----------
-        datasePtct : `lsst.cp.pipe.ptc.PhotonTransferCurveDataset`
-            The dataset containing information such as the means, variances and exposure times.
-            nLinearity
-
-        detector : `lsst.afw.cameraGeom.Detector`
-            Detector object.
-
-        tableArray : `np.array`, optional
-            Optional. Look-up table array with size rows=nAmps and columns=DN values.
-            It will be modified in-place if supplied.
-
-        log : `lsst.log.Log`, optional
-            Logger to handle messages.
-
-        Returns
-        -------
-        linearizer : `lsst.ip.isr.Linearizer`
-            Linearizer object
-        """
-
-        # Fit NonLinearity
-        datasetNonLinearity = self.fitNonLinearity(datasetPtc, tableArray=tableArray)
-
-        # Produce linearizer
-        now = datetime.datetime.utcnow()
-        calibDate = now.strftime("%Y-%m-%d")
-        linType = self.config.linearizerType
-
-        if linType == "LOOKUPTABLE":
-            tableArray = tableArray
-        else:
-            tableArray = None
-
-        linearizer = self.buildLinearizerObject(datasetNonLinearity, detector, calibDate, linType,
-                                                instruName=self.config.instrumentName,
-                                                tableArray=tableArray,
-                                                log=log)
-
-        return linearizer
-
-    def fitNonLinearity(self, datasetPtc, tableArray=None):
-        """Fit a polynomial to signal vs effective time curve to calculate linearity and residuals.
-
-        Parameters
-        ----------
-        datasetPtc : `lsst.cp.pipe.ptc.PhotonTransferCurveDataset`
-            The dataset containing the means, variances and exposure times.
-
-        tableArray : `np.array`
-            Optional. Look-up table array with size rows=nAmps and columns=DN values.
-            It will be modified in-place if supplied.
-
-        Returns
-        -------
-        datasetNonLinearity : `dict`
-            Dictionary of `lsst.cp.pipe.ptc.LinearityResidualsAndLinearizersDataset`
-            dataclasses. Each one holds the output of `calculateLinearityResidualAndLinearizers` per
-            amplifier.
-        """
-        datasetNonLinearity = {ampName: [] for ampName in datasetPtc.ampNames}
-        for i, ampName in enumerate(datasetPtc.ampNames):
-            # If a mask is not found, use all points.
-            if (len(datasetPtc.visitMask[ampName]) == 0):
-                self.log.warn(f"Mask not found for {ampName} in non-linearity fit. Using all points.")
-                mask = np.repeat(True, len(datasetPtc.rawExpTimes[ampName]))
-            else:
-                mask = datasetPtc.visitMask[ampName]
-
-            timeVecFinal = np.array(datasetPtc.rawExpTimes[ampName])[mask]
-            meanVecFinal = np.array(datasetPtc.rawMeans[ampName])[mask]
-
-            # Non-linearity residuals (NL of mean vs time curve): percentage, and fit to a quadratic function
-            # In this case, len(parsIniNonLinearity) = 3 indicates that we want a quadratic fit
-            datasetLinRes = self.calculateLinearityResidualAndLinearizers(timeVecFinal, meanVecFinal)
-
-            # LinearizerLookupTable
-            if tableArray is not None:
-                tableArray[i, :] = datasetLinRes.linearizerTableRow
-
-            datasetNonLinearity[ampName] = datasetLinRes
-
-        return datasetNonLinearity
-
-    def calculateLinearityResidualAndLinearizers(self, exposureTimeVector, meanSignalVector):
-        """Calculate linearity residual and fit an n-order polynomial to the mean vs time curve
-        to produce corrections (deviation from linear part of polynomial) for a particular amplifier
-        to populate LinearizeLookupTable.
-        Use the coefficients of this fit to calculate the correction coefficients for  LinearizePolynomial
-        and LinearizeSquared."
-
-        Parameters
-        ---------
-
-        exposureTimeVector: `list` of `float`
-            List of exposure times for each flat pair
-
-        meanSignalVector: `list` of `float`
-            List of mean signal from diference image of flat pairs
-
-        Returns
-        -------
-        dataset : `lsst.cp.pipe.ptc.LinearityResidualsAndLinearizersDataset`
-            The dataset containing the fit parameters, the NL correction coefficients, and the
-            LUT row for the amplifier at hand.
-
-        Notes
-        -----
-        datase members:
-
-        dataset.polynomialLinearizerCoefficients : `list` of `float`
-            Coefficients for LinearizePolynomial, where corrImage = uncorrImage + sum_i c_i uncorrImage^(2 +
-            i).
-            c_(j-2) = -k_j/(k_1^j) with units DN^(1-j) (c.f., Eq. 37 of 2003.05978). The units of k_j are
-            DN/t^j, and they are fit from meanSignalVector = k0 + k1*exposureTimeVector +
-            k2*exposureTimeVector^2 + ... + kn*exposureTimeVector^n, with
-            n = "polynomialFitDegreeNonLinearity". k_0 and k_1 and degenerate with bias level and gain,
-            and are not used by the non-linearity correction. Therefore, j = 2...n in the above expression
-            (see `LinearizePolynomial` class in `linearize.py`.)
-
-        dataset.quadraticPolynomialLinearizerCoefficient : `float`
-            Coefficient for LinearizeSquared, where corrImage = uncorrImage + c0*uncorrImage^2.
-            c0 = -k2/(k1^2), where k1 and k2 are fit from
-            meanSignalVector = k0 + k1*exposureTimeVector + k2*exposureTimeVector^2 +...
-                               + kn*exposureTimeVector^n, with n = "polynomialFitDegreeNonLinearity".
-
-        dataset.linearizerTableRow : `list` of `float`
-           One dimensional array with deviation from linear part of n-order polynomial fit
-           to mean vs time curve. This array will be one row (for the particular amplifier at hand)
-           of the table array for LinearizeLookupTable.
-
-        dataset.meanSignalVsTimePolyFitPars  : `list` of `float`
-            Parameters from n-order polynomial fit to meanSignalVector vs exposureTimeVector.
-
-        dataset.meanSignalVsTimePolyFitParsErr : `list` of `float`
-            Parameters from n-order polynomial fit to meanSignalVector vs exposureTimeVector.
-
-        dataset.meanSignalVsTimePolyFitReducedChiSq  : `float`
-            Reduced unweighted chi squared from polynomial fit to meanSignalVector vs exposureTimeVector.
-        """
-
-        # Lookup table linearizer
-        parsIniNonLinearity = self._initialParsForPolynomial(self.config.polynomialFitDegreeNonLinearity + 1)
-        if self.config.doFitBootstrap:
-            (parsFit, parsFitErr,
-             reducedChiSquaredNonLinearityFit) = fitBootstrap(parsIniNonLinearity,
-                                                              exposureTimeVector,
-                                                              meanSignalVector,
-                                                              funcPolynomial,
-                                                              weightsY=1./np.sqrt(meanSignalVector))
-        else:
-            (parsFit, parsFitErr,
-             reducedChiSquaredNonLinearityFit) = fitLeastSq(parsIniNonLinearity,
-                                                            exposureTimeVector,
-                                                            meanSignalVector,
-                                                            funcPolynomial,
-                                                            weightsY=1./np.sqrt(meanSignalVector))
-
-        # LinearizeLookupTable:
-        # Use linear part to get time at wich signal is maxAduForLookupTableLinearizer DN
-        tMax = (self.config.maxAduForLookupTableLinearizer - parsFit[0])/parsFit[1]
-        timeRange = np.linspace(0, tMax, self.config.maxAduForLookupTableLinearizer)
-        signalIdeal = parsFit[0] + parsFit[1]*timeRange
-        signalUncorrected = funcPolynomial(parsFit, timeRange)
-        linearizerTableRow = signalIdeal - signalUncorrected  # LinearizerLookupTable has corrections
-        # LinearizePolynomial and LinearizeSquared:
-        # Check that magnitude of higher order (>= 3) coefficents of the polyFit are small,
-        # i.e., less than threshold = 1e-10 (typical quadratic and cubic coefficents are ~1e-6
-        # and ~1e-12).
-        k1 = parsFit[1]
-        polynomialLinearizerCoefficients = []
-        for i, coefficient in enumerate(parsFit):
-            c = -coefficient/(k1**i)
-            polynomialLinearizerCoefficients.append(c)
-            if np.fabs(c) > 1e-10:
-                msg = f"Coefficient {c} in polynomial fit larger than threshold 1e-10."
-                self.log.warn(msg)
-        # Coefficient for LinearizedSquared. Called "c0" in linearize.py
-        c0 = polynomialLinearizerCoefficients[2]
-
-        dataset = LinearityResidualsAndLinearizersDataset([], None, [], [], [], None)
-        dataset.polynomialLinearizerCoefficients = polynomialLinearizerCoefficients
-        dataset.quadraticPolynomialLinearizerCoefficient = c0
-        dataset.linearizerTableRow = linearizerTableRow
-        dataset.meanSignalVsTimePolyFitPars = parsFit
-        dataset.meanSignalVsTimePolyFitParsErr = parsFitErr
-        dataset.meanSignalVsTimePolyFitReducedChiSq = reducedChiSquaredNonLinearityFit
-
-        return dataset
-
-    def buildLinearizerObject(self, datasetNonLinearity, detector, calibDate, linearizerType, instruName='',
-                              tableArray=None, log=None):
-        """Build linearizer object to persist.
-
-        Parameters
-        ----------
-        datasetNonLinearity : `dict`
-            Dictionary of `lsst.cp.pipe.ptc.LinearityResidualsAndLinearizersDataset` objects.
-
-        detector : `lsst.afw.cameraGeom.Detector`
-            Detector object
-
-        calibDate : `datetime.datetime`
-            Calibration date
-
-        linearizerType : `str`
-            'LOOKUPTABLE', 'LINEARIZESQUARED', or 'LINEARIZEPOLYNOMIAL'
-
-        instruName : `str`, optional
-            Instrument name
-
-        tableArray : `np.array`, optional
-            Look-up table array with size rows=nAmps and columns=DN values
-
-        log : `lsst.log.Log`, optional
-            Logger to handle messages
-
-        Returns
-        -------
-        linearizer : `lsst.ip.isr.Linearizer`
-            Linearizer object
-        """
-        detName = detector.getName()
-        detNum = detector.getId()
-        if linearizerType == "LOOKUPTABLE":
-            if tableArray is not None:
-                linearizer = Linearizer(detector=detector, table=tableArray, log=log)
-            else:
-                raise RuntimeError("tableArray must be provided when creating a LookupTable linearizer")
-        elif linearizerType in ("LINEARIZESQUARED", "LINEARIZEPOLYNOMIAL"):
-            linearizer = Linearizer(log=log)
-        else:
-            raise RuntimeError("Invalid linearizerType {linearizerType} to build a Linearizer object. "
-                               "Supported: 'LOOKUPTABLE', 'LINEARIZESQUARED', or 'LINEARIZEPOLYNOMIAL'")
-        for i, amp in enumerate(detector.getAmplifiers()):
-            ampName = amp.getName()
-            datasetNonLinAmp = datasetNonLinearity[ampName]
-            if linearizerType == "LOOKUPTABLE":
-                linearizer.linearityCoeffs[ampName] = [i, 0]
-                linearizer.linearityType[ampName] = "LookupTable"
-            elif linearizerType == "LINEARIZESQUARED":
-                linearizer.fitParams[ampName] = datasetNonLinAmp.meanSignalVsTimePolyFitPars
-                linearizer.fitParamsErr[ampName] = datasetNonLinAmp.meanSignalVsTimePolyFitParsErr
-                linearizer.linearityFitReducedChiSquared[ampName] = (
-                    datasetNonLinAmp.meanSignalVsTimePolyFitReducedChiSq)
-                linearizer.linearityCoeffs[ampName] = [
-                    datasetNonLinAmp.quadraticPolynomialLinearizerCoefficient]
-                linearizer.linearityType[ampName] = "Squared"
-            elif linearizerType == "LINEARIZEPOLYNOMIAL":
-                linearizer.fitParams[ampName] = datasetNonLinAmp.meanSignalVsTimePolyFitPars
-                linearizer.fitParamsErr[ampName] = datasetNonLinAmp.meanSignalVsTimePolyFitParsErr
-                linearizer.linearityFitReducedChiSquared[ampName] = (
-                    datasetNonLinAmp.meanSignalVsTimePolyFitReducedChiSq)
-                # Slice correction coefficients (starting at 2) for polynomial linearizer
-                # (and squared linearizer above). The first and second are reduntant with
-                # the bias and gain, respectively, and are not used by LinearizerPolynomial.
-                polyLinCoeffs = np.array(datasetNonLinAmp.polynomialLinearizerCoefficients[2:])
-                linearizer.linearityCoeffs[ampName] = polyLinCoeffs
-                linearizer.linearityType[ampName] = "Polynomial"
-            linearizer.linearityBBox[ampName] = amp.getBBox()
-        linearizer.validate()
-        calibId = f"detectorName={detName} detector={detNum} calibDate={calibDate} ccd={detNum} filter=NONE"
-
-        try:
-            raftName = detName.split("_")[0]
-            calibId += f" raftName={raftName}"
-        except Exception:
-            raftname = "NONE"
-            calibId += f" raftName={raftname}"
-
-        serial = detector.getSerial()
-        linearizer.updateMetadata(instrumentName=instruName, detectorId=f"{detNum}",
-                                  calibId=calibId, serial=serial, detectorName=f"{detName}")
-
-        return linearizer
 
     @staticmethod
     def _initialParsForPolynomial(order):


### PR DESCRIPTION
Move linearity calibration construction out of `ptc.py`, and make the new task gen3 compliant.