### PR TITLE
DM-26031: Fix broken measureCrosstalk test

### DIFF
--- a/python/lsst/cp/pipe/measureCrosstalk.py
+++ b/python/lsst/cp/pipe/measureCrosstalk.py
@@ -217,7 +217,8 @@ class CrosstalkExtractTask(pipeBase.PipelineTask,
 
             for sourceAmp in sourceDetector:
                 sourceAmpName = sourceAmp.getName()
-                sourceAmpImage = sourceIm[sourceAmp.getBBox()]
+                sourceAmpBBox = sourceAmp.getBBox() if self.config.isTrimmed else sourceAmp.getRawDataBBox()
+                sourceAmpImage = sourceIm[sourceAmpBBox]
                 sourceMask = sourceAmpImage.mask.array
                 select = ((sourceMask & detected > 0)
                           & (sourceMask & bad == 0)

--- a/tests/test_measureCrosstalk.py
+++ b/tests/test_measureCrosstalk.py
@@ -115,9 +115,7 @@ class MeasureCrosstalkTaskCases(lsst.utils.tests.TestCase):
         """
         goodFitMask = self.setup_measureCrosstalk(isTrimmed=False, nSources=8)
 
-        # DM-26031 This doesn't always fully converge, so be permissive
-        # for now.
-        self.assertTrue(np.any(goodFitMask))
+        self.assertTrue(np.all(goodFitMask))
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
Fix bbox issue behind the untrimmed unit test failures.

Although CrosstalkExtractTask had a config parameter for the trimmed
state, it wasn't using it consistently.