### PR TITLE
DM-29699: CalibCombineConnections changes its quantum dimensions at construction

### DIFF
--- a/pipelines/cpFlat.yaml
+++ b/pipelines/cpFlat.yaml
@@ -28,13 +28,12 @@ tasks:
       connections.inputMDs: 'flatStats'
       connections.outputScales: 'cpFlatNormScales'
   cpFlatCombine:
-    class: lsst.cp.pipe.cpCombine.CalibCombineTask
+    class: lsst.cp.pipe.cpCombine.CalibCombineByFilterTask
     config:
       connections.inputExps: 'cpFlatProc'
       connections.inputScales: 'cpFlatNormScales'
       connections.outputData: 'flat'
       calibrationType: 'flat'
-      calibrationDimensions: ['physical_filter']
       exposureScaling: InputList
       scalingLevel: AMP
 contracts:

--- a/pipelines/cpFlatSingleChip.yaml
+++ b/pipelines/cpFlatSingleChip.yaml
@@ -18,12 +18,11 @@ tasks:
       doFringe: False
       doApplyGains: False
   cpFlatCombine:
-    class: lsst.cp.pipe.cpCombine.CalibCombineTask
+    class: lsst.cp.pipe.cpCombine.CalibCombineByFilterTask
     config:
       connections.inputExps: 'cpFlatProc'
       connections.outputData: 'flat'
       calibrationType: 'flat'
-      calibrationDimensions: ['physical_filter']
       exposureScaling: MeanStats
 contracts:
   - isr.doFlat == False

--- a/pipelines/cpFringe.yaml
+++ b/pipelines/cpFringe.yaml
@@ -22,12 +22,11 @@ tasks:
       connections.inputExp: 'cpFringeIsr'
       connections.outputExp: 'cpFringeProc'
   cpFringeCombine:
-    class: lsst.cp.pipe.cpCombine.CalibCombineTask
+    class: lsst.cp.pipe.cpCombine.CalibCombineByFilterTask
     config:
       connections.inputExps: 'cpFringeProc'
       connections.outputData: 'fringe'
       calibrationType: 'fringe'
-      calibrationDimensions: ['physical_filter']
       exposureScaling: "Unity"
 contracts:
   - isr.doFringe == False

--- a/python/lsst/cp/pipe/cpCombine.py
+++ b/python/lsst/cp/pipe/cpCombine.py
@@ -510,6 +510,14 @@ class CalibCombineByFilterConnections(CalibCombineConnections,
         multiple=False,
     )
 
+    outputData = cT.Output(
+        name="cpFilterProposal",
+        doc="Output combined proposed calibration.",
+        storageClass="ExposureF",
+        dimensions=("instrument", "detector", "physical_filter"),
+        isCalibration=True,
+    )
+
     def __init__(self, *, config=None):
         super().__init__(config=config)
 

--- a/python/lsst/cp/pipe/cpCombine.py
+++ b/python/lsst/cp/pipe/cpCombine.py
@@ -502,11 +502,23 @@ class CalibCombineTask(pipeBase.PipelineTask,
 # Create versions of the Connections, Config, and Task that support filter constraints.
 class CalibCombineByFilterConnections(CalibCombineConnections,
                                       dimensions=("instrument", "detector", "physical_filter")):
-    pass
+    inputScales = cT.Input(
+        name="cpFilterScales",
+        doc="Input scale factors to use.",
+        storageClass="StructuredDataDict",
+        dimensions=("instrument", "physical_filter"),
+        multiple=False,
+    )
+
+    def __init__(self, *, config=None):
+        super().__init__(config=config)
+
+        if config and config.exposureScaling != 'InputList':
+            self.inputs.discard("inputScales")
 
 
 class CalibCombineByFilterConfig(CalibCombineConfig,
-                                 pipelineConnections=CalibCombineConnections):
+                                 pipelineConnections=CalibCombineByFilterConnections):
     pass
 
 

--- a/python/lsst/cp/pipe/cpCombine.py
+++ b/python/lsst/cp/pipe/cpCombine.py
@@ -111,7 +111,7 @@ class CalibCombineConnections(pipeBase.PipelineTaskConnections,
 
     outputData = cT.Output(
         name="cpProposal",
-        doc="Output combined proposed calibration.",
+        doc="Output combined proposed calibration to be validated and certified..",
         storageClass="ExposureF",
         dimensions=("instrument", "detector"),
         isCalibration=True,
@@ -512,7 +512,7 @@ class CalibCombineByFilterConnections(CalibCombineConnections,
 
     outputData = cT.Output(
         name="cpFilterProposal",
-        doc="Output combined proposed calibration.",
+        doc="Output combined proposed calibration to be validated and certified.",
         storageClass="ExposureF",
         dimensions=("instrument", "detector", "physical_filter"),
         isCalibration=True,

--- a/python/lsst/cp/pipe/cpCombine.py
+++ b/python/lsst/cp/pipe/cpCombine.py
@@ -117,6 +117,12 @@ class CalibCombineConnections(pipeBase.PipelineTaskConnections,
         isCalibration=True,
     )
 
+    def __init__(self, *, config=None):
+        super().__init__(config=config)
+
+        if config and config.exposureScaling != 'InputList':
+            self.inputs.discard("inputScales")
+
 
 # CalibCombineConfig/CalibCombineTask from pipe_base/constructCalibs.py
 class CalibCombineConfig(pipeBase.PipelineTaskConfig,

--- a/python/lsst/cp/pipe/cpCombine.py
+++ b/python/lsst/cp/pipe/cpCombine.py
@@ -117,34 +117,6 @@ class CalibCombineConnections(pipeBase.PipelineTaskConnections,
         isCalibration=True,
     )
 
-    def __init__(self, *, config=None):
-        super().__init__(config=config)
-
-        if config and config.exposureScaling != 'InputList':
-            self.inputs.discard("inputScales")
-
-        if config and len(config.calibrationDimensions) != 0:
-            newDimensions = tuple(config.calibrationDimensions)
-            newOutputData = cT.Output(
-                name=self.outputData.name,
-                doc=self.outputData.doc,
-                storageClass=self.outputData.storageClass,
-                dimensions=self.allConnections['outputData'].dimensions + newDimensions,
-                isCalibration=True,
-            )
-            self.dimensions.update(config.calibrationDimensions)
-            self.outputData = newOutputData
-
-            if config.exposureScaling == 'InputList':
-                newInputScales = cT.PrerequisiteInput(
-                    name=self.inputScales.name,
-                    doc=self.inputScales.doc,
-                    storageClass=self.inputScales.storageClass,
-                    dimensions=self.allConnections['inputScales'].dimensions + newDimensions
-                )
-                self.dimensions.update(config.calibrationDimensions)
-                self.inputScales = newInputScales
-
 
 # CalibCombineConfig/CalibCombineTask from pipe_base/constructCalibs.py
 class CalibCombineConfig(pipeBase.PipelineTaskConfig,
@@ -155,11 +127,6 @@ class CalibCombineConfig(pipeBase.PipelineTaskConfig,
         dtype=str,
         default="calibration",
         doc="Name of calibration to be generated.",
-    )
-    calibrationDimensions = pexConfig.ListField(
-        dtype=str,
-        default=[],
-        doc="List of updated dimensions to append to output."
     )
 
     exposureScaling = pexConfig.ChoiceField(
@@ -524,6 +491,24 @@ class CalibCombineTask(pipeBase.PipelineTask,
         array[bad] = median
         if count > 0:
             self.log.warn("Found %s NAN pixels", count)
+
+
+# Create versions of the Connections, Config, and Task that support filter constraints.
+class CalibCombineByFilterConnections(CalibCombineConnections,
+                                      dimensions=("instrument", "detector", "physical_filter")):
+    pass
+
+
+class CalibCombineByFilterConfig(CalibCombineConfig,
+                                 pipelineConnections=CalibCombineConnections):
+    pass
+
+
+class CalibCombineByFilterTask(CalibCombineTask):
+    """Task to combine calib exposures."""
+    ConfigClass = CalibCombineByFilterConfig
+    _DefaultName = 'cpFilterCombine'
+    pass
 
 
 def VignetteExposure(exposure, polygon=None,


### PR DESCRIPTION
Use separate classes for the cpCombine step when it does and does not use the 'physical_filter' dimension.

The new CalibCombineByFilter Connections, Config, and Task now inherit
from their respective CalibCombine counterparts, but simply add the
new dimension.  This avoids the previous work around to have the
dimensions edited on construction.

Update the pipeline definitions for this as well.