### PR TITLE
DM-22534: Implement cpSkyTask

### DIFF
--- a/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpSkyCombineTask.rst
+++ b/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpSkyCombineTask.rst
@@ -1,0 +1,38 @@
+.. lsst-task-topic:: lsst.cp.pipe.cpSkyTask.CpSkyCombine
+
+############
+CpSkyCombine
+############
+
+``CpSkyCombine`` averages the per-exposure background models into a final SKY calibration.
+
+.. _lsst.cp.pipe.cpSkyTask.CpSkyCombine-processing-summary:
+
+Processing summary
+==================
+
+``CpSkyCombine`` runs these operations:
+
+#. Average input backgrounds with :lsst-task:`~lsst.pipe.drivers.SkyMeasurementTask`.
+#. Combine input headers for the output calibration.
+
+.. _lsst.cp.pipe.cpSkyTask.CpSkyCombine-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.cp.pipe.cpSkyTask.CpSkyCombine
+
+.. _lsst.cp.pipe.cpSkyTask.CpSkyCombine-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.cp.pipe.cpSkyTask.CpSkyCombine
+
+.. _lsst.cp.pipe.cpSkyTask.CpSkyCombine-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.cp.pipe.cpSkyTask.CpSkyCombine

--- a/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpSkyImageTask.rst
+++ b/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpSkyImageTask.rst
@@ -1,0 +1,38 @@
+.. lsst-task-topic:: lsst.cp.pipe.cpSkyTask.CpSkyImage
+
+##############
+CpSkyImageTask
+##############
+
+``CpSkyImageTask`` preprocesses exposures after :lsst-task:`~lsst.ip.isr.IsrTask` to mask detections so a cleaner background estimate can be measured.
+
+.. _lsst.cp.pipe.cpSkyTask.CpSkyImage-processing-summary:
+
+Processing summary
+==================
+
+``CpSkyImageTask`` runs these operations:
+
+#. Run :lsst-task:`~lsst.pipe.drivers.background.MaskObjectsTask` to identify and mask sources in the image.
+#. Construct a single-detector `~lsst.pipe.drivers.background.FocalPlaneBackground` model from the detection clean image.
+
+.. _lsst.cp.pipe.cpSkyTask.CpSkyImage-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.cp.pipe.cpSkyTask.CpSkyImage
+
+.. _lsst.cp.pipe.cpSkyTask.CpSkyImage-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.cp.pipe.cpSkyTask.CpSkyImage
+
+.. _lsst.cp.pipe.cpSkyTask.CpSkyImage-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.cp.pipe.cpSkyTask.CpSkyImage

--- a/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpSkyScaleMeasureTask.rst
+++ b/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpSkyScaleMeasureTask.rst
@@ -1,0 +1,38 @@
+.. lsst-task-topic:: lsst.cp.pipe.cpSkyTask.CpSkyScaleMeasure
+
+#################
+CpSkyScaleMeasure
+#################
+
+``CpSkyScaleMeasure`` merges the `lsst.pipe.drivers.FocalPlaneBackground` models generated per-detector into single full-focal plane model.
+
+.. _lsst.cp.pipe.cpSkyTask.CpSkyScaleMeasure-processing-summary:
+
+Processing summary
+==================
+
+``CpSkyScaleMeasure`` runs these operations:
+
+#. Merges per-detector models together.
+#. Measures the median of the model statistics image to determine the per-exposure scale factor.
+
+.. _lsst.cp.pipe.cpSkyTask.CpSkyScaleMeasure-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.cp.pipe.cpSkyTask.CpSkyScaleMeasure
+
+.. _lsst.cp.pipe.cpSkyTask.CpSkyScaleMeasure-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.cp.pipe.cpSkyTask.CpSkyScaleMeasure
+
+.. _lsst.cp.pipe.cpSkyTask.CpSkyScaleMeasure-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.cp.pipe.cpSkyTask.CpSkyScaleMeasure

--- a/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpSkyScaleMeasureTask.rst
+++ b/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpSkyScaleMeasureTask.rst
@@ -4,7 +4,7 @@
 CpSkyScaleMeasure
 #################
 
-``CpSkyScaleMeasure`` merges the `lsst.pipe.drivers.FocalPlaneBackground` models generated per-detector into single full-focal plane model.
+``CpSkyScaleMeasure`` merges the `lsst.pipe.drivers.FocalPlaneBackground` models generated per-detector into a single full-focal plane model.
 
 .. _lsst.cp.pipe.cpSkyTask.CpSkyScaleMeasure-processing-summary:
 

--- a/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpSkySubtractBackgroundTask.rst
+++ b/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpSkySubtractBackgroundTask.rst
@@ -4,14 +4,14 @@
 CpSkySubtractBackground
 #######################
 
-``CpSubtractBackground`` subtracts the scaled full-focal plane model created by :lsst-task:`~lsst.cp.pipe.CpSkyScaleMeasureTask` from the per-detector images created by :lsst-task:`~lsst.cp.pipe.CpSkyImageTask`.
+``CpSkySubtractBackground`` subtracts the scaled full-focal plane model created by :lsst-task:`~lsst.cp.pipe.CpSkyScaleMeasureTask` from the per-detector images created by :lsst-task:`~lsst.cp.pipe.CpSkyImageTask`.
 
 .. _lsst.cp.pipe.cpSkyTask.CpSkySubtractBackground-processing-summary:
 
 Processing summary
 ==================
 
-``CpSubtractBackground`` runs these operations:
+``CpSkySubtractBackground`` runs these operations:
 
 #. Subtract the scaled focal-plane model from the per-detector image.
 #. Remeasure the residual background.

--- a/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpSkySubtractBackgroundTask.rst
+++ b/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpSkySubtractBackgroundTask.rst
@@ -1,0 +1,38 @@
+.. lsst-task-topic:: lsst.cp.pipe.cpSkyTask.CpSkySubtractBackground
+
+#######################
+CpSkySubtractBackground
+#######################
+
+``CpSubtractBackground`` subtracts the scaled full-focal plane model created by :lsst-task:`~lsst.cp.pipe.CpSkyScaleMeasureTask` from the per-detector images created by :lsst-task:`~lsst.cp.pipe.CpSkyImageTask`.
+
+.. _lsst.cp.pipe.cpSkyTask.CpSkySubtractBackground-processing-summary:
+
+Processing summary
+==================
+
+``CpSubtractBackground`` runs these operations:
+
+#. Subtract the scaled focal-plane model from the per-detector image.
+#. Remeasure the residual background.
+
+.. _lsst.cp.pipe.cpSkyTask.CpSkySubtractBackground-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.cp.pipe.cpSkyTask.CpSkySubtractBackground
+
+.. _lsst.cp.pipe.cpSkyTask.CpSkySubtractBackground-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.cp.pipe.cpSkyTask.CpSkySubtractBackground
+
+.. _lsst.cp.pipe.cpSkyTask.CpSkySubtractBackground-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.cp.pipe.cpSkyTask.CpSkySubtractBackground

--- a/pipelines/Latiss/cpSky.yaml
+++ b/pipelines/Latiss/cpSky.yaml
@@ -1,0 +1,13 @@
+description: Sky frame generation pipeline definition.
+instrument: lsst.obs.lsst.Latiss
+imports:
+  -  location: $CP_PIPE_DIR/pipelines/cpSky.yaml
+tasks:
+  isr:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.outputExposure: cpSkyIsr
+      overscan.fitType: 'MEDIAN_PER_ROW'
+      doLinearize: False
+      doCrosstalk: True
+      doBrighterFatter: False

--- a/pipelines/cpSky.yaml
+++ b/pipelines/cpSky.yaml
@@ -4,9 +4,6 @@ tasks:
     class: lsst.ip.isr.isrTask.IsrTask
     config:
       connections.outputExposure: cpSkyIsr
-      doLinearize: False
-      doCrosstalk: True
-      doBrighterFatter: False
   cpSkyImage:
     class: lsst.cp.pipe.CpSkyImageTask
   cpSkyScaleMeasure:

--- a/pipelines/cpSky.yaml
+++ b/pipelines/cpSky.yaml
@@ -1,0 +1,17 @@
+description: Sky frame generation pipeline definition.
+tasks:
+  isr:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.outputExposure: cpSkyIsr
+      doLinearize: False
+      doCrosstalk: True
+      doBrighterFatter: False
+  cpSkyImage:
+    class: lsst.cp.pipe.CpSkyImageTask
+  cpSkyScaleMeasure:
+    class: lsst.cp.pipe.CpSkyScaleMeasureTask
+  cpSkySubtractBackground:
+    class: lsst.cp.pipe.CpSkySubtractBackgroundTask
+  cpSkyCombine:
+    class: lsst.cp.pipe.CpSkyCombineTask

--- a/python/lsst/cp/pipe/__init__.py
+++ b/python/lsst/cp/pipe/__init__.py
@@ -28,3 +28,4 @@ from .ptc import *
 from .cpCombine import *
 from .measureCrosstalk import *
 from .linearity import *
+from .cpSkyTask import *

--- a/python/lsst/cp/pipe/cpSkyTask.py
+++ b/python/lsst/cp/pipe/cpSkyTask.py
@@ -23,13 +23,12 @@ import numpy as np
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
 import lsst.pipe.base.connectionTypes as cT
-import lsst.afw.math as afwMath
-import lsst.afw.image as afwImage
 
 from lsst.pipe.drivers.background import (FocalPlaneBackground, MaskObjectsTask, SkyMeasurementTask,
-                                          FocalPlaneBackgroundConfig, BackgroundConfig)
+                                          FocalPlaneBackgroundConfig)
 from lsst.daf.base import PropertyList
 from ._lookupStaticCalibration import lookupStaticCalibration
+from .cpCombine import CalibCombineTask
 
 __all__ = ['CpSkyImageTask', 'CpSkyImageConfig',
            'CpSkyScaleMeasureTask', 'CpSkyScaleMeasureConfig',

--- a/python/lsst/cp/pipe/cpSkyTask.py
+++ b/python/lsst/cp/pipe/cpSkyTask.py
@@ -30,7 +30,6 @@ from lsst.pipe.drivers.background import (FocalPlaneBackground, MaskObjectsTask,
                                           FocalPlaneBackgroundConfig, BackgroundConfig)
 from lsst.daf.base import PropertyList
 from ._lookupStaticCalibration import lookupStaticCalibration
-from .cpCombine import CalibCombineTask
 
 __all__ = ['CpSkyImageTask', 'CpSkyImageConfig',
            'CpSkyScaleMeasureTask', 'CpSkyScaleMeasureConfig',

--- a/python/lsst/cp/pipe/cpSkyTask.py
+++ b/python/lsst/cp/pipe/cpSkyTask.py
@@ -1,0 +1,437 @@
+# This file is part of cp_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import numpy as np
+
+import lsst.pex.config as pexConfig
+import lsst.pipe.base as pipeBase
+import lsst.pipe.base.connectionTypes as cT
+import lsst.afw.math as afwMath
+import lsst.afw.image as afwImage
+
+from ._lookupStaticCalibration import lookupStaticCalibration
+from .cpCombine import CalibCombineTask
+
+from lsst.pipe.drivers.background import (FocalPlaneBackground, MaskObjectsTask, SkyMeasurementTask,
+                                          FocalPlaneBackgroundConfig, BackgroundConfig)
+
+__all__ = ["CpSkyTask", "CpSkyTaskConfig"]
+
+
+class CpSkyImageConnections(pipeBase.PipelineTaskConnections,
+                            dimensions=("instrument", "physical_filter", "exposure", "detector")):
+    inputExp = cT.Input(
+        name="cpSkyIsr",
+        doc="Input pre-processed exposures to combine.",
+        storageClass="ExposureF",
+        dimensions=("instrument", "exposure", "detector"),
+    )
+    camera = cT.PrerequisiteInput(
+        name="camera",
+        doc="Input camera to use for geometry.",
+        storageClass="Camera",
+        dimensions=("instrument",),
+        lookupFunction=lookupStaticCalibration,
+        isCalibration=True,
+    )
+
+    maskedExp = cT.Output(
+        name="cpSkyMaskedIsr",
+        doc="Output masked post-ISR exposure.",
+        storageClass="ExposureF",
+        dimensions=("instrument", "exposure", "detector"),
+    )
+    maskedBkg = cT.Output(
+        name="cpSkyDetectorBackground",
+        doc="Initial background model from one image.",
+        storageClass="FocalPlaneBackground",
+        dimensions=("instrument", "exposure", "detector"),
+    )
+
+
+class CpSkyImageConfig(pipeBase.PipelineTaskConfig,
+                       pipelineConnections=CpSkyImageConnections):
+    maskTask = pexConfig.ConfigurableField(
+        target=MaskObjectsTask,
+        doc="Object masker to use.",
+    )
+
+    maskThresh = pexConfig.Field(
+        dtype=float,
+        default=3.0,
+        doc="k-sigma threshold for masking pixels.",
+    )
+    maskList = pexConfig.ListField(
+        dtype=str,
+        default=["DETECTED", "BAD", "NO_DATA", "SAT"],
+        doc="Mask planes to reject.",
+    )
+
+    largeScaleBackground = pexConfig.ConfigField(
+        dtype=FocalPlaneBackgroundConfig,
+        doc="Large-scale background configuration",
+    )
+
+    def setDefaults(self):
+        self.largeScaleBackground.xSize = 256
+        self.largeScaleBackground.ySize = 256
+
+
+# cpSkyMaskedIsr_{per exposure,detector} = map(applyMask, list(cpSkyProc))
+class CpSkyImageTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
+    """Mask the detections on the postISRCCD
+    """
+    ConfigClass = CpSkyImageConfig
+    _DefaultName = "CpSkyImage"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.makeSubtask("maskTask")
+
+    def run(self, inputExp, camera):
+        """Mask the detections on the postISRCCD.
+
+        CZW: Write docstring.
+        """
+        # Duplicate ST.processSingleBackground
+        self.maskObjects.run(inputExp, self.config.maskList)
+
+        # Duplicate ST.measureBackground
+        bgModel = FocalPlaneBackground.fromCamera(self.config.largeScalBackground, camera)
+        bgModel.addCcd(inputExp)
+
+        return pipeBase.Struct(
+            outputExp=inputExp,
+            outputBkg=bgModel,
+        )
+
+
+class CpSkyScaleMeasureConnections(pipeBase.PipelineTaskConnections,
+                                   dimensions=("instrument", "physical_filter", "exposure")):
+    inputBkgs = cT.Input(
+        name="cpSkyDetectorBackground",
+        doc="Initial background model from one exposure/detector",
+        storageClass="FocalPlaneBackground",
+        dimensions=("instrument", "exposure", "detector"),
+        multiple=True
+    )
+
+    outputBkg = cT.Output(
+        name="cpSkyExpBackground",
+        doc="Background model for a full exposure.",
+        storageClass="FocalPlaneBackground",
+        dimensions=("instrument", "exposure"),
+    )
+    outputScale = cT.Output(
+        name="cpSkyExpScale",
+        doc="Scale for the full exposure.",
+        storageClass="PropertyList",
+        dimensions=("instrument", "exposure"),
+    )
+
+
+class CpSkyScaleMeasureConfig(pipeBase.PiplineTaskConfig,
+                              pipelineConnections=CpSkyScaleMeasureConnections):
+    pass
+
+
+# (bg, scales)_{per exposure} = reduce(cpSkyMaskedIsr)_{over detector}
+class CpSkyScaleMeasureTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
+    """Measure per-exposure scale factors and merge focal plane backgrounds.
+    """
+    ConfigClass = CpSkyScaleMeasureConfig
+    _DefaultName = "cpSkyScaleMeasure"
+
+    def run(self, inputBkgs):
+        """Merge per-exposure scale factors and merge focal plane backgrounds.
+
+        CZW: Write docstrings.
+        """
+        background = inputBkgs[0]
+        for bg in inputBkgs[1:]:
+            background.merge(bg)
+
+        scale = np.median(background.getStatsImage().getArray())
+        return pipeBase.Struct(
+            outputBkg=background,
+            outputScale=scale,
+        )
+
+
+class CpSkySubtractBackgroundConnections(pipeBase.PipelineTaskConnections,
+                                         dimensions=("instrument", "physical_filter",
+                                                     "exposure", "detector")):
+    inputExp = cT.Input(
+        name="cpSkyMaskedIsr",
+        doc="Masked post-ISR image.",
+        storageClass="ExposureF",
+        dimensions=("instrument", "exposure", "detector"),
+    )
+    inputBkg = cT.Input(
+        name="cpSkyExpBackground",
+        doc="Background model for the full exposure.",
+        storageClass="FocalPlaneBackground",
+        dimensions=("instrument", "exposure"),
+    )
+    inputScale = cT.Input(
+        name="cpSkyExpScale",
+        doc="Scale for the full exposure.",
+        storageClass="PropertyList",
+        dimensions=("instrument", "exposure"),
+    )
+
+    outputBkg = cT.Input(
+        name="icExpBackground",
+        doc="Normalized, static background.",
+        storageClass="FocalPlaneBackground",
+        dimensions=("instrument", "exposure", "detector"),
+    )
+
+
+class CpSkySubtractBackgroundConfig(pipeBase.PipelineTaskConfig,
+                                    pipelineConnections=CpSkySubtractBackgroundConnections):
+    sky = pexConfig.ConfigurableField(
+        target=SkyMeasurementTask,
+        doc="Sky measurement",
+    )
+
+
+# icExpBkg_{per exposure, detector} = map(subtractBackground(bg_{exp}, scale_{exp}),
+#                                         list(cpSkyMaskedIsr))
+class CpSkySubtractBackgroundTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
+    """Subtract per-exposure background from individual detector masked images.
+    """
+    ConfigClass = CpSkySubtractBackgroundConfig
+    _DefaultName = "cpSkySubtractBkg"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.makeSubtask("sky")
+
+    def run(self, inputExp, inputBkg, inputScale):
+        """Subtract per-exposure background from individual detector masked images.
+
+        CZW: Write docstrings.
+        """
+        image = inputExp.getMaskedImage()
+        detector = inputExp.getDetector()
+        bbox = image.getBBox()
+
+        background = inputBkg.toCcdBackground(detector, bbox)
+        image -= background.getImage()
+        image /= inputScale
+
+        newBackground = self.sky.measureBackground(image)
+        return pipeBase.Struct(
+            outputBkg=newBackground
+        )
+
+
+class CpSkyCombineConnections(pipeBase.PipelineTaskConnections,
+                              dimensions=("instrument", "physical_filter", "detector")):
+    inputBkgs = cT.Input(
+        name="icExpBackground",
+        doc="Normalized, static background.",
+        storageClass="FocalPlaneBackground",
+        dimensions=("instrument", "exposure", "detector"),
+        multiple=True
+    )
+
+    outputCalib = cT.Output(
+        name="sky",
+        doc="Averaged static background.",
+        storageClass="FocalPlaneBackground",
+        dimensions=("instrument", "detector"),
+        isCalibration=True,
+    )
+
+
+class CpSkyCombineConfig(pipeBase.PipelineTaskConfig,
+                         pipelineConnections=CpSkyCombineConnections):
+    sky = pexConfig.ConfigurableField(
+        target=SkyMeasurementTask,
+        doc="Sky measurement",
+    )
+
+
+# skyCalib_{per detector} = reduce(icExpBkg)_{over exposure}
+class CpSkyCombineTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
+    """Merge per-exposure measurements into a detector level calibration.
+    """
+    ConfigClass = CpSkyCombineConfig
+    _DefaultName = "cpSkyCombine"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.makeSubtask("sky")
+
+    def run(self, inputBkgs):
+        """Merge per-exposure measurements into a detector level calibration.
+
+        CZW: Write docstrings.
+        """
+        skyCalib = self.sky.averageBackgrounds(inputBkgs)
+        # This is a placeholder:
+        CalibCombineTask().combineHeaders(inputBkgs, skyCalib, calibType='SKY')
+
+        return pipeBase.Struct(
+            outputCalib=skyCalib,
+        )
+
+
+class CpSkyConnections(pipeBase.PipelineTaskConnections,
+                       dimensions=("instrument", "visit", "detector")):
+    inputExp = cT.Input(
+        name="cpSkyISR",
+        doc="Input pre-processed exposures to combine.",
+        storageClass="ExposureF",
+        dimensions=("instrument", "visit", "detector"),
+    )
+    camera = cT.PrerequisiteInput(
+        name="camera",
+        doc="Input camera for full focal plane backgrounds.",
+        storageClass="Camera",
+        dimensions=("instrument", "calibration_label"),
+    )
+
+    outputExp = cT.Output(
+        name="cpSkyProc",
+        doc="Output combined proposed calibration.",
+        storageClass="ExposureF",
+        dimensions=("instrument", "visit", "detector"),
+    )
+
+
+class CpSkyTaskConfig(pipeBase.PipelineTaskConfig,
+                      pipelineConnections=CpSkyConnections):
+    maskObjects = pexConfig.ConfigurableField(
+        target=MaskObjectsTask,
+        doc="Object masker to use.",
+    )
+    maskThresh = pexConfig.Field(
+        dtype=float,
+        default=3.0,
+        doc="k-sigma threshold for masking pixels"
+    )
+    mask = pexConfig.ListField(
+        dtype=str,
+        default=["BAD", "SAT", "DETECTED", "NO_DATA"],
+        doc="Mask planes to reject.",
+    )
+
+    largeScaleBackground = pexConfig.ConfigField(
+        dtype=FocalPlaneBackgroundConfig,
+        doc="Large-scale background configuration"
+    )
+    sky = pexConfig.ConfigurableField(
+        target=SkyMeasurementTask,
+        doc="Sky measurement"
+    )
+    background = pexConfig.ConfigField(
+        dtype=BackgroundConfig,
+        doc="Background config.",
+    )
+
+    # CZW:?
+    detectSigma = pexConfig.Field(
+        dtype=float,
+        default=2.0,
+        doc="Detection PSF Gaussian sigma.",
+    )
+
+    def setDefaults(self):
+        self.largeScaleBackground.xSize = 256
+        self.largeScaleBackground.ySize = 256
+
+
+class CpSkyTask(pipeBase.PipelineTask,
+                pipeBase.CmdLineTask):
+    ConfigClass = CpSkyTaskConfig
+    _DefaultName = "cpSky"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.makeSubtask("maskObjects")
+        self.makeSubtask("sky")
+
+    def run(self, inputExp, camera):
+        """Preprocess ISR processed exposures for combination to final SKY calibration.
+
+        DM-22534: This isn't scaling correctly, and needs fixing.
+
+        Parameters
+        ----------
+        inputExp : `lsst.afw.image.Exposure`
+            Pre-processed sky frame data to combine.
+        camera : `lsst.afw.cameraGeom.Camera`
+            Camera to use for focal-plane geometry.
+
+        Returns
+        -------
+        outputExp : `lsst.afw.image.Exposure`
+            Sky pre-processed data.
+        """
+        # As constructCalibs SkyTask.processSingleBackground
+        self.maskObjects.run(inputExp, self.config.mask)
+
+        # As constructCalibs SkyTask.measureBackground
+        bgModel = FocalPlaneBackground.fromCamera(self.config.largeScaleBackground,
+                                                  camera)
+        bgModel.addCcd(inputExp)
+
+        scale = np.median(bgModel.getStatsImage().getArray())
+
+        # As constructCalibs SkyTask.scatterProcess
+        # Remeasure bkg with scaled version of the FP model removed
+        mi = inputExp.getMaskedImage()
+
+        bg = bgModel.toCcdBackground(inputExp.getDetector(), mi.getBBox())
+        mi -= bg.getImage()
+        mi /= scale
+
+        # As constructCalibs SkyTask.processSingle
+        # Make the equivalent of the gen2 icExpBackground product.
+        stats = afwMath.StatisticsControl()
+        stats.setAndMask(mi.getMask().getPlaneBitMask(self.config.background.mask))
+        stats.setNanSafe(True)
+        ctrl = afwMath.BackgroundControl(
+            self.config.background.algorithm,
+            max(int(mi.getWidth() / self.config.background.xBinSize + 0.5), 1),
+            max(int(mi.getHeight() / self.config.background.yBinSize + 0.5), 1),
+            "REDUCE_INTERP_ORDER",
+            stats,
+            self.config.background.statistic
+        )
+
+        bgNew = afwMath.makeBackground(mi, ctrl)
+        icExpBkg = afwMath.BackgroundList((
+            bgNew,
+            afwMath.stringToInterpStyle(self.config.background.algorithm),
+            afwMath.stringToUndersampleStyle("REDUCE_INTERP_ORDER"),
+            afwMath.ApproximateControl.UNKNOWN,
+            0, 0, False
+        ))
+
+        bgExp = afwImage.makeExposure(icExpBkg[0][0].getStatsImage())
+
+        # Return
+        return pipeBase.Struct(
+            outputExp=bgExp,
+        )

--- a/python/lsst/cp/pipe/cpSkyTask.py
+++ b/python/lsst/cp/pipe/cpSkyTask.py
@@ -360,7 +360,7 @@ class CpSkyCombineConnections(pipeBase.PipelineTaskConnections,
     outputCalib = cT.Output(
         name="sky",
         doc="Averaged static background.",
-        storageClass="Exposure",
+        storageClass="ExposureF",
         dimensions=("instrument", "detector", "physical_filter"),
         isCalibration=True,
     )

--- a/python/lsst/cp/pipe/cpSkyTask.py
+++ b/python/lsst/cp/pipe/cpSkyTask.py
@@ -340,7 +340,7 @@ class CpSkySubtractBackgroundTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
 class CpSkyCombineConnections(pipeBase.PipelineTaskConnections,
                               dimensions=("instrument", "physical_filter", "detector")):
     inputBkgs = cT.Input(
-        name="icExpBackground",
+        name="cpExpBackground",
         doc="Normalized, static background.",
         storageClass="Background",
         dimensions=("instrument", "exposure", "detector"),

--- a/python/lsst/cp/pipe/cpSkyTask.py
+++ b/python/lsst/cp/pipe/cpSkyTask.py
@@ -108,8 +108,8 @@ class CpSkyImageTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
     This task maps the MaskObjectsTask across all of the initial ISR
     processed cpSkyIsr images to create cpSkyMaskedIsr products for
     all (exposure, detector) values.
-
     """
+
     ConfigClass = CpSkyImageConfig
     _DefaultName = "CpSkyImage"
 
@@ -197,6 +197,7 @@ class CpSkyScaleMeasureTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
     plane background for each exposure, and measure the scale factor
     from that full background.
     """
+
     ConfigClass = CpSkyScaleMeasureConfig
     _DefaultName = "cpSkyScaleMeasure"
 
@@ -293,6 +294,7 @@ class CpSkySubtractBackgroundTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
     created here has definition clashes that prevent that from being
     reused.
     """
+
     ConfigClass = CpSkySubtractBackgroundConfig
     _DefaultName = "cpSkySubtractBkg"
 
@@ -301,7 +303,8 @@ class CpSkySubtractBackgroundTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
         self.makeSubtask("sky")
 
     def run(self, inputExp, inputBkg, inputScale):
-        """Subtract per-exposure background from individual detector masked images.
+        """Subtract per-exposure background from individual detector masked
+        images.
 
         Parameters
         ----------
@@ -380,6 +383,7 @@ class CpSkyCombineTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
     As before, this is written to a skyCalib instead of a SKY to avoid
     definition classes in gen3.
     """
+
     ConfigClass = CpSkyCombineConfig
     _DefaultName = "cpSkyCombine"
 

--- a/python/lsst/cp/pipe/cpSkyTask.py
+++ b/python/lsst/cp/pipe/cpSkyTask.py
@@ -87,16 +87,16 @@ class CpSkyImageConfig(pipeBase.PipelineTaskConfig,
 
     largeScaleBackground = pexConfig.ConfigField(
         dtype=FocalPlaneBackgroundConfig,
-        doc="Large-scale background configuration",
+        doc="Large-scale background configuration.",
     )
 
     def setDefaults(self):
-        # self.largeScaleBackground.xSize = 256
-        # self.largeScaleBackground.ySize = 256
-        # obs_subaru values
-        self.largeScaleBackground.xSize = 122.88
-        self.largeScaleBackground.ySize = 122.88
-        self.largeScaleBackground.pixelSize = 0.015
+        # These values correspond to the HSC recommendation.  As noted
+        # below, the sizes are in millimeters, and correspond to an
+        # background image 8192x8192 pixels (8192*0.015=122.88).
+        self.largeScaleBackground.xSize = 122.88  # in mm
+        self.largeScaleBackground.ySize = 122.88  # in mm
+        self.largeScaleBackground.pixelSize = 0.015  # in mm per pixel
         self.largeScaleBackground.minFrac = 0.1
         self.largeScaleBackground.mask = ['BAD', 'SAT', 'INTRP', 'DETECTED', 'DETECTED_NEGATIVE',
                                           'EDGE', 'NO_DATA']
@@ -150,7 +150,7 @@ class CpSkyImageTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
         else:
             self.maskTask.run(inputExp, self.config.maskList)
 
-        # As constructCalibs.py  SkyTask.measureBackground()
+        # As constructCalibs.py SkyTask.measureBackground()
         bgModel = FocalPlaneBackground.fromCamera(self.config.largeScaleBackground, camera)
         bgModel.addCcd(inputExp)
 

--- a/python/lsst/cp/pipe/cpSkyTask.py
+++ b/python/lsst/cp/pipe/cpSkyTask.py
@@ -410,6 +410,8 @@ class CpSkyCombineTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                 The final sky calibration product.
         """
         skyCalib = self.sky.averageBackgrounds(inputBkgs)
+        skyCalib.setDetector(inputExps[0].getDetector())
+
         CalibCombineTask().combineHeaders(inputExps, skyCalib, calibType='SKY')
 
         return pipeBase.Struct(

--- a/python/lsst/cp/pipe/cpSkyTask.py
+++ b/python/lsst/cp/pipe/cpSkyTask.py
@@ -355,7 +355,7 @@ class CpSkyCombineConnections(pipeBase.PipelineTaskConnections,
     )
 
     outputCalib = cT.Output(
-        name="skyCalib",
+        name="sky",
         doc="Averaged static background.",
         storageClass="Exposure",
         dimensions=("instrument", "detector", "physical_filter"),


### PR DESCRIPTION
This ticket re-implements pipe_drivers constructCalib.py SkyTask in gen3, using four tasks to handle the map-reduce-map-reduce structure of the old code.