### PR TITLE
DM-23330: Doxygen warnings in pipe_base

### DIFF
--- a/ups/cp_pipe.cfg
+++ b/ups/cp_pipe.cfg
@@ -8,7 +8,7 @@ import lsst.sconsUtils
 # Otherwise, the rules for which packages to list here are the same as those for
 # table files.
 dependencies = {
-    "required": ["pex_config", "pipe_base", "log", "ip_isr", "afw", "meas_algorithms"],
+    "required": ["pex_config", "log", "ip_isr", "afw", "meas_algorithms"],
     "buildRequired": [],
     "optional": [],
     "buildOptional": [],


### PR DESCRIPTION
This PR fixes a build error caused by converting `pipe_base` to a pure-Python package in lsst/pipe_base#184.