### PR TITLE
DM-29338: Incorporate Gen 3 crosstalk in HiTS runs

### DIFF
--- a/pipelines/DarkEnergyCamera/RunIsrForCrosstalkSources.yaml
+++ b/pipelines/DarkEnergyCamera/RunIsrForCrosstalkSources.yaml
@@ -1,0 +1,4 @@
+description: Prepare crosstalkSources for ISR/interchip crosstalk by running overscan correction on raw frames.
+instrument: lsst.obs.decam.DarkEnergyCamera
+imports:
+  - location: $AP_PIPE_DIR/pipelines/DarkEnergyCamera/RunIsrForCrosstalkSources.yaml

--- a/pipelines/DarkEnergyCamera/cpFlat.yaml
+++ b/pipelines/DarkEnergyCamera/cpFlat.yaml
@@ -1,0 +1,17 @@
+description: cp_pipe FLAT calibration construction for DECam
+# Use RunIsrForCrosstalkSources.yaml BEFORE running this pipeline
+# so the raw flat frames have inter-chip crosstalk corrected.
+instrument: lsst.obs.decam.DarkEnergyCamera
+imports:
+  - location: $CP_PIPE_DIR/pipelines/cpFlat.yaml
+tasks:
+  isr:
+    class: lsst.ip.isr.IsrTask
+    config:
+      connections.crosstalkSources: 'overscanRaw'
+      connections.bias: 'bias'
+      doDark: False
+  cpFlatMeasure:
+    class: lsst.cp.pipe.cpFlatNormTask.CpFlatMeasureTask
+    config:
+      doVignette: False

--- a/pipelines/cpBias.yaml
+++ b/pipelines/cpBias.yaml
@@ -1,7 +1,7 @@
 description: cp_pipe BIAS calibration construction
 tasks:
   isr:
-    class: lsst.ip.isr.isrTask.IsrTask
+    class: lsst.ip.isr.IsrTask
     config:
       connections.ccdExposure: 'raw'
       connections.outputExposure: 'cpBiasProc'

--- a/pipelines/cpDark.yaml
+++ b/pipelines/cpDark.yaml
@@ -1,7 +1,7 @@
 description: cp_pipe DARK calibration construction
 tasks:
   isr:
-    class: lsst.ip.isr.isrTask.IsrTask
+    class: lsst.ip.isr.IsrTask
     config:
       connections.ccdExposure: 'raw'
       connections.outputExposure: 'cpDarkIsr'

--- a/pipelines/cpFlat.yaml
+++ b/pipelines/cpFlat.yaml
@@ -1,7 +1,7 @@
 description: cp_pipe FLAT calibration construction optimized for single-CCD cameras
 tasks:
   isr:
-    class: lsst.ip.isr.isrTask.IsrTask
+    class: lsst.ip.isr.IsrTask
     config:
       connections.ccdExposure: 'raw'
       connections.outputExposure: 'cpFlatProc'

--- a/pipelines/cpFlatSingleChip.yaml
+++ b/pipelines/cpFlatSingleChip.yaml
@@ -1,7 +1,7 @@
 description: cp_pipe FLAT calibration construction
 tasks:
   isr:
-    class: lsst.ip.isr.isrTask.IsrTask
+    class: lsst.ip.isr.IsrTask
     config:
       connections.ccdExposure: 'raw'
       connections.outputExposure: 'cpFlatProc'

--- a/pipelines/cpFringe.yaml
+++ b/pipelines/cpFringe.yaml
@@ -1,7 +1,7 @@
 description: cp_pipe FRINGE calibration construction
 tasks:
   isr:
-    class: lsst.ip.isr.isrTask.IsrTask
+    class: lsst.ip.isr.IsrTask
     config:
       connections.ccdExposure: 'raw'
       connections.outputExposure: 'cpFringeIsr'

--- a/pipelines/findDefects.yaml
+++ b/pipelines/findDefects.yaml
@@ -1,7 +1,7 @@
 description: cp_pipe DEFECT calibration construction.
 tasks:
   isr:
-    class: lsst.ip.isr.isrTask.IsrTask
+    class: lsst.ip.isr.IsrTask
     config:
       connections.ccdExposure: 'raw'
       connections.outputExposure: 'cpDefectsProc'

--- a/pipelines/measureCrosstalk.yaml
+++ b/pipelines/measureCrosstalk.yaml
@@ -1,7 +1,7 @@
 description: cp_pipe CROSSTALK calibration construction.
 tasks:
   isr:
-    class: lsst.ip.isr.isrTask.IsrTask
+    class: lsst.ip.isr.IsrTask
     config:
       connections.ccdExposure: 'raw'
       connections.outputExposure: 'cpCrosstalkProc'

--- a/pipelines/measurePhotonTransferCurve.yaml
+++ b/pipelines/measurePhotonTransferCurve.yaml
@@ -4,7 +4,7 @@ parameters:
     measuredCovariances: cpCovariances
 tasks:
   isr:
-    class: lsst.ip.isr.isrTask.IsrTask
+    class: lsst.ip.isr.IsrTask
     config:
       connections.ccdExposure: raw
       connections.outputExposure: parameters.exposureName
@@ -38,5 +38,5 @@ tasks:
       connections.inputCovariances: parameters.measuredCovariances
       connections.outputPtcDataset: ptc
       ptcFitType: FULLCOVARIANCE
-contracts: 
+contracts:
   - ptcSolve.maximumRangeCovariancesAstier == ptcExtract.maximumRangeCovariancesAstier


### PR DESCRIPTION
This PR adds a DECam flat-building pipeline, and necessarily standardizes ISR task names so yaml imports work.