### PR TITLE
DM-31096: Fix bitrot in gen3 linearity solver

### DIFF
--- a/pipelines/Latiss/cpLinearitySolve.yaml
+++ b/pipelines/Latiss/cpLinearitySolve.yaml
@@ -1,0 +1,11 @@
+description: cp_pipe linearity calibration construction.
+instrument: lsst.obs.lsst.Latiss
+imports:
+  - location: $CP_PIPE_DIR/pipelines/cpLinearitySolve.yaml
+tasks:
+  linearitySolve:
+    class: lsst.cp.pipe.LinearitySolveTask
+    config:
+      linearityType: Spline
+      splineKnots: 10
+      maxLinearAdu: 120000

--- a/pipelines/cpLinearitySolve.yaml
+++ b/pipelines/cpLinearitySolve.yaml
@@ -1,0 +1,7 @@
+description: cp_pipe linearity calibration construction.
+tasks:
+  linearitySolve:
+    class: lsst.cp.pipe.LinearitySolveTask
+    config:
+      connections.inputPtc: ptc
+      connections.outputLinearizer: linearity

--- a/python/lsst/cp/pipe/linearity.py
+++ b/python/lsst/cp/pipe/linearity.py
@@ -117,6 +117,11 @@ class LinearitySolveConfig(pipeBase.PipelineTaskConfig,
         doc="Maximum deviation from linear solution for Poissonian noise.",
         default=5.0,
     )
+    ignorePtcMask = pexConfig.Field(
+        dtype=bool,
+        doc="Ignore the values masked by PTC?",
+        default=False,
+    )
 
 
 class LinearitySolveTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
@@ -202,11 +207,33 @@ class LinearitySolveTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
 
         for i, amp in enumerate(detector):
             ampName = amp.getName()
-            if (len(inputPtc.expIdMask[ampName]) == 0):
+            if ampName in inputPtc.badAmps:
+                linearizer.linearityType[ampName] = "None"
+
+                nEntries = 1
+                if self.config.linearityType in ['Polynomial']:
+                    nEntries = fitOrder + 1
+                elif self.config.linearityType in ['Spline']:
+                    nEntries = fitOrder * 2
+                elif self.config.linearityType in ['Squared', 'None']:
+                    nEntries = 1
+                elif self.config.linearityType in ['LookupTable']:
+                    nEntries = 2
+
+                coeffs = np.zeros(nEntries)
+                linearizer.linearityCoeffs[ampName] = coeffs
+                linearizer.linearityBBox[ampName] = amp.getBBox()
+                linearizer.fitParams[ampName] = np.array([0.0])
+                linearizer.fitParamsErr[ampName] = np.array([0.0])
+                linearizer.fitChiSq[ampName] = np.nan
+                self.log.warn("Amp %s has no usable PTC information.  Skipping!", ampName)
+                continue
+
+            if (len(inputPtc.expIdMask[ampName]) == 0) or self.config.ignorePtcMask:
                 self.log.warn(f"Mask not found for {ampName} in non-linearity fit. Using all points.")
                 mask = np.repeat(True, len(inputPtc.expIdMask[ampName]))
             else:
-                mask = inputPtc.expIdMask[ampName]
+                mask = np.array(inputPtc.expIdMask[ampName], dtype=bool)
 
             inputAbscissa = np.array(inputPtc.rawExpTimes[ampName])[mask]
             inputOrdinate = np.array(inputPtc.rawMeans[ampName])[mask]

--- a/python/lsst/cp/pipe/linearity.py
+++ b/python/lsst/cp/pipe/linearity.py
@@ -208,23 +208,25 @@ class LinearitySolveTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
         for i, amp in enumerate(detector):
             ampName = amp.getName()
             if ampName in inputPtc.badAmps:
-                linearizer.linearityType[ampName] = "None"
-
                 nEntries = 1
+                pEntries = 1
                 if self.config.linearityType in ['Polynomial']:
                     nEntries = fitOrder + 1
+                    pEntries = fitOrder + 1
                 elif self.config.linearityType in ['Spline']:
                     nEntries = fitOrder * 2
                 elif self.config.linearityType in ['Squared', 'None']:
                     nEntries = 1
+                    pEntries = fitOrder + 1
                 elif self.config.linearityType in ['LookupTable']:
                     nEntries = 2
+                    pEntries = fitOrder + 1
 
-                coeffs = np.zeros(nEntries)
-                linearizer.linearityCoeffs[ampName] = coeffs
+                linearizer.linearityType[ampName] = "None"
+                linearizer.linearityCoeffs[ampName] = np.zeros(nEntries)
                 linearizer.linearityBBox[ampName] = amp.getBBox()
-                linearizer.fitParams[ampName] = np.array([0.0])
-                linearizer.fitParamsErr[ampName] = np.array([0.0])
+                linearizer.fitParams[ampName] = np.zeros(pEntries)
+                linearizer.fitParamsErr[ampName] = np.zeros(pEntries)
                 linearizer.fitChiSq[ampName] = np.nan
                 self.log.warn("Amp %s has no usable PTC information.  Skipping!", ampName)
                 continue

--- a/python/lsst/cp/pipe/linearity.py
+++ b/python/lsst/cp/pipe/linearity.py
@@ -119,7 +119,7 @@ class LinearitySolveConfig(pipeBase.PipelineTaskConfig,
     )
     ignorePtcMask = pexConfig.Field(
         dtype=bool,
-        doc="Ignore the values masked by PTC?",
+        doc="Ignore the expIdMask set by the PTC solver?",
         default=False,
     )
 
@@ -158,6 +158,10 @@ class LinearitySolveTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
         ----------
         inputPtc : `lsst.cp.pipe.PtcDataset`
             Pre-measured PTC dataset.
+        dummy : `lsst.afw.image.Exposure`
+            The exposure used to select the appropriate PTC dataset.
+            In almost all circumstances, one of the input exposures
+            used to generate the PTC dataset is the best option.
         camera : `lsst.afw.cameraGeom.Camera`
             Camera geometry.
         inputDims : `lsst.daf.butler.DataCoordinate` or `dict`

--- a/python/lsst/cp/pipe/makeBrighterFatterKernel.py
+++ b/python/lsst/cp/pipe/makeBrighterFatterKernel.py
@@ -173,8 +173,10 @@ class BrighterFatterKernelSolveTask(pipeBase.PipelineTask, pipeBase.CmdLineTask)
         ----------
         inputPtc : `lsst.ip.isr.PhotonTransferCurveDataset`
             PTC data containing per-amplifier covariance measurements.
-        dummy : `lsst.afw.image.Exposure
+        dummy : `lsst.afw.image.Exposure`
             The exposure used to select the appropriate PTC dataset.
+            In almost all circumstances, one of the input exposures
+            used to generate the PTC dataset is the best option.
         camera : `lsst.afw.cameraGeom.Camera`
             Camera to use for camera geometry information.
         inputDims : `lsst.daf.butler.DataCoordinate` or `dict`

--- a/tests/test_ptc.py
+++ b/tests/test_ptc.py
@@ -203,12 +203,14 @@ class MeasurePhotonTransferCurveTaskTestCase(lsst.utils.tests.TestCase):
             localDataset = solveTask.fitPtc(localDataset)
             # linDataset here is a lsst.pipe.base.Struct
             linDataset = linearityTask.run(localDataset,
+                                           dummy=[1.0],
                                            camera=FakeCamera([self.flatExp1.getDetector()]),
                                            inputDims={'detector': 0})
             linDataset = linDataset.outputLinearizer
         else:
             localDataset = solveTask.fitPtc(localDataset)
             linDataset = linearityTask.run(localDataset,
+                                           dummy=[1.0],
                                            camera=FakeCamera([self.flatExp1.getDetector()]),
                                            inputDims={'detector': 0})
             linDataset = linDataset.outputLinearizer


### PR DESCRIPTION
This largely duplicates the gen3 connections in the brighter-fatter code (which also works off of the PTC dataset).
Additional handlers were added to ensure that the length of the output fields match between solvable and unsolveable amplifiers.  If the lengths do not match, an error is thrown by the FITS writing code.