### PR TITLE
DM-29981: Migrate cp_pipe pipelines as defined in RFC-775

### DIFF
--- a/pipelines/HyperSuprimeCam/cpBias.yaml
+++ b/pipelines/HyperSuprimeCam/cpBias.yaml
@@ -1,0 +1,4 @@
+description: obs_subaru/HSC bias calibration construction
+instrument: lsst.obs.subaru.HyperSuprimeCam
+imports:
+  location: $CP_PIPE_DIR/pipelines/cpBias.yaml

--- a/pipelines/HyperSuprimeCam/cpDark.yaml
+++ b/pipelines/HyperSuprimeCam/cpDark.yaml
@@ -1,0 +1,4 @@
+description: obs_subaru/HSC dark calibration construction
+instrument: lsst.obs.subaru.HyperSuprimeCam
+imports:
+  location: $CP_PIPE_DIR/pipelines/cpDark.yaml

--- a/pipelines/HyperSuprimeCam/cpFlat.yaml
+++ b/pipelines/HyperSuprimeCam/cpFlat.yaml
@@ -1,0 +1,4 @@
+description: obs_subaru/HSC flat calibration construction
+instrument: lsst.obs.subaru.HyperSuprimeCam
+imports:
+  location: $CP_PIPE_DIR/pipelines/cpFlat.yaml

--- a/pipelines/HyperSuprimeCam/cpFringe.yaml
+++ b/pipelines/HyperSuprimeCam/cpFringe.yaml
@@ -1,0 +1,4 @@
+description: obs_subaru/HSC fringe calibration construction
+instrument: lsst.obs.subaru.HyperSuprimeCam
+imports:
+  location: $CP_PIPE_DIR/pipelines/cpFringe.yaml

--- a/pipelines/Latiss/cpBfkSolve.yaml
+++ b/pipelines/Latiss/cpBfkSolve.yaml
@@ -1,4 +1,4 @@
-description: Latiss PTC calibration construction.
+description: Latiss Brighter-Fatter kernel calibration construction.
 instrument: lsst.obs.lsst.Latiss
 imports:
   - location: $CP_PIPE_DIR/pipelines/cpBfkSolve.yaml

--- a/pipelines/Latiss/cpBfkSolve.yaml
+++ b/pipelines/Latiss/cpBfkSolve.yaml
@@ -1,9 +1,4 @@
-description: cp_pipe PTC calibration construction.
+description: Latiss PTC calibration construction.
 instrument: lsst.obs.lsst.Latiss
-tasks:
-  bfkSolve:
-    class: lsst.cp.pipe.BrighterFatterKernelSolveTask
-    config:
-      connections.inputPtc: ptc
-      connections.outputBFK: bfk
-
+imports:
+  - location: $CP_PIPE_DIR/pipelines/cpBfkSolve.yaml

--- a/pipelines/Latiss/cpBfkSolve.yaml
+++ b/pipelines/Latiss/cpBfkSolve.yaml
@@ -1,0 +1,9 @@
+description: cp_pipe PTC calibration construction.
+instrument: lsst.obs.lsst.Latiss
+tasks:
+  bfkSolve:
+    class: lsst.cp.pipe.BrighterFatterKernelSolveTask
+    config:
+      connections.inputPtc: ptc
+      connections.outputBFK: bfk
+

--- a/pipelines/Latiss/cpBias.yaml
+++ b/pipelines/Latiss/cpBias.yaml
@@ -1,0 +1,34 @@
+description: obs_lsst/latiss bias calibration construction
+instrument: lsst.obs.lsst.Latiss
+# Do not inherit until defect/linearize/ct work
+# inherits:
+#  location: $CP_PIPE_DIR/pipelines/cpBias.yaml
+tasks:
+  isr:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.outputExposure: 'cpBiasProc'
+      doBias: False
+      doVariance: True
+      doLinearize: True
+      doCrosstalk: False
+      doDefect: True
+      doNanMasking: True
+      doInterpolate: True
+      doBrighterFatter: False
+      doDark: False
+      doFlat: False
+      doApplyGains: False
+      doFringe: False
+  cpBiasCombine:
+    class: lsst.cp.pipe.cpCombine.CalibCombineTask
+    config:
+      connections.inputExps: 'cpBiasProc'
+      connections.outputData: 'bias'
+      calibrationType: 'bias'
+      exposureScaling: "Unity"
+contracts:
+  - isr.doBias == False
+  - cpBiasCombine.calibrationType == "bias"
+  - cpBiasCombine.exposureScaling == "Unity"

--- a/pipelines/Latiss/cpBias.yaml
+++ b/pipelines/Latiss/cpBias.yaml
@@ -4,7 +4,7 @@ imports:
   - location: $CP_PIPE_DIR/pipelines/cpBias.yaml
 tasks:
   isr:
-    class: lsst.ip.isr.isrTask.IsrTask
+    class: lsst.ip.isr.IsrTask
     config:
       # Disable these until useful calibrations exist.
       doLinearize: False

--- a/pipelines/Latiss/cpBias.yaml
+++ b/pipelines/Latiss/cpBias.yaml
@@ -6,7 +6,8 @@ tasks:
   isr:
     class: lsst.ip.isr.IsrTask
     config:
-      doDefect: True
+      overscan.fitType: 'MEDIAN_PER_ROW'
+      doDefect: False
       # Disable these until useful calibrations exist.
       doLinearize: False
       doCrosstalk: False

--- a/pipelines/Latiss/cpBias.yaml
+++ b/pipelines/Latiss/cpBias.yaml
@@ -1,34 +1,12 @@
-description: obs_lsst/latiss bias calibration construction
+description: Latiss bias calibration construction
 instrument: lsst.obs.lsst.Latiss
-# Do not inherit until defect/linearize/ct work
-# inherits:
-#  location: $CP_PIPE_DIR/pipelines/cpBias.yaml
+imports:
+  - location: $CP_PIPE_DIR/pipelines/cpBias.yaml
 tasks:
   isr:
     class: lsst.ip.isr.isrTask.IsrTask
     config:
-      connections.ccdExposure: 'raw'
-      connections.outputExposure: 'cpBiasProc'
-      doBias: False
-      doVariance: True
-      doLinearize: True
+      # Disable these until useful calibrations exist.
+      doLinearize: False
       doCrosstalk: False
-      doDefect: True
-      doNanMasking: True
-      doInterpolate: True
-      doBrighterFatter: False
-      doDark: False
-      doFlat: False
-      doApplyGains: False
-      doFringe: False
-  cpBiasCombine:
-    class: lsst.cp.pipe.cpCombine.CalibCombineTask
-    config:
-      connections.inputExps: 'cpBiasProc'
-      connections.outputData: 'bias'
-      calibrationType: 'bias'
-      exposureScaling: "Unity"
-contracts:
-  - isr.doBias == False
-  - cpBiasCombine.calibrationType == "bias"
-  - cpBiasCombine.exposureScaling == "Unity"
+      doDefect: False

--- a/pipelines/Latiss/cpBias.yaml
+++ b/pipelines/Latiss/cpBias.yaml
@@ -6,7 +6,7 @@ tasks:
   isr:
     class: lsst.ip.isr.IsrTask
     config:
+      doDefect: True
       # Disable these until useful calibrations exist.
       doLinearize: False
       doCrosstalk: False
-      doDefect: False

--- a/pipelines/Latiss/cpDark.yaml
+++ b/pipelines/Latiss/cpDark.yaml
@@ -1,40 +1,12 @@
-description: obs_lsst/latiss dark calibration construction
+description: Latiss dark calibration construction
 instrument: lsst.obs.lsst.Latiss
-# Do not inherit until defect/linearize/ct work
-# inherits:
-#  location: $CP_PIPE_DIR/pipelines/cpDark.yaml
+imports:
+  -  location: $CP_PIPE_DIR/pipelines/cpDark.yaml
 tasks:
   isr:
     class: lsst.ip.isr.isrTask.IsrTask
     config:
-      connections.ccdExposure: 'raw'
-      connections.outputExposure: 'cpDarkIsr'
-      doBias: True
-      doVariance: True
+      # Disable these until valid calibrations exist.
       doLinearize: False
       doCrosstalk: False
-      doDefect: True
-      doNanMasking: True
-      doInterpolate: True
-      doBrighterFatter: False
-      doDark: False
-      doFlat: False
-      doApplyGains: False
-      doFringe: False
-  cpDark:
-    class: lsst.cp.pipe.cpDarkTask.CpDarkTask
-    config:
-      connections.inputExp: 'cpDarkIsr'
-      connections.outputExp: 'cpDarkProc'
-  cpDarkCombine:
-    class: lsst.cp.pipe.cpCombine.CalibCombineTask
-    config:
-      connections.inputExps: 'cpDarkProc'
-      connections.outputData: 'dark'
-      calibrationType: 'dark'
-      exposureScaling: "DarkTime"
-      python: config.mask.append("CR")
-contracts:
-  - isr.doDark == False
-  - cpDarkCombine.calibrationType == "dark"
-  - cpDarkCombine.exposureScaling == "DarkTime"
+      doDefect: False

--- a/pipelines/Latiss/cpDark.yaml
+++ b/pipelines/Latiss/cpDark.yaml
@@ -4,7 +4,7 @@ imports:
   -  location: $CP_PIPE_DIR/pipelines/cpDark.yaml
 tasks:
   isr:
-    class: lsst.ip.isr.isrTask.IsrTask
+    class: lsst.ip.isr.IsrTask
     config:
       # Disable these until valid calibrations exist.
       doLinearize: False

--- a/pipelines/Latiss/cpDark.yaml
+++ b/pipelines/Latiss/cpDark.yaml
@@ -1,0 +1,40 @@
+description: obs_lsst/latiss dark calibration construction
+instrument: lsst.obs.lsst.Latiss
+# Do not inherit until defect/linearize/ct work
+# inherits:
+#  location: $CP_PIPE_DIR/pipelines/cpDark.yaml
+tasks:
+  isr:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.outputExposure: 'cpDarkIsr'
+      doBias: True
+      doVariance: True
+      doLinearize: False
+      doCrosstalk: False
+      doDefect: True
+      doNanMasking: True
+      doInterpolate: True
+      doBrighterFatter: False
+      doDark: False
+      doFlat: False
+      doApplyGains: False
+      doFringe: False
+  cpDark:
+    class: lsst.cp.pipe.cpDarkTask.CpDarkTask
+    config:
+      connections.inputExp: 'cpDarkIsr'
+      connections.outputExp: 'cpDarkProc'
+  cpDarkCombine:
+    class: lsst.cp.pipe.cpCombine.CalibCombineTask
+    config:
+      connections.inputExps: 'cpDarkProc'
+      connections.outputData: 'dark'
+      calibrationType: 'dark'
+      exposureScaling: "DarkTime"
+      python: config.mask.append("CR")
+contracts:
+  - isr.doDark == False
+  - cpDarkCombine.calibrationType == "dark"
+  - cpDarkCombine.exposureScaling == "DarkTime"

--- a/pipelines/Latiss/cpDark.yaml
+++ b/pipelines/Latiss/cpDark.yaml
@@ -10,4 +10,4 @@ tasks:
       overscan.fitType: 'MEDIAN_PER_ROW'
       doLinearize: False
       doCrosstalk: False
-      doDefect: False
+      doDefect: True

--- a/pipelines/Latiss/cpDark.yaml
+++ b/pipelines/Latiss/cpDark.yaml
@@ -7,6 +7,7 @@ tasks:
     class: lsst.ip.isr.IsrTask
     config:
       # Disable these until valid calibrations exist.
+      overscan.fitType: 'MEDIAN_PER_ROW'
       doLinearize: False
       doCrosstalk: False
       doDefect: False

--- a/pipelines/Latiss/cpFlat.yaml
+++ b/pipelines/Latiss/cpFlat.yaml
@@ -10,4 +10,3 @@ tasks:
       overscan.fitType: 'MEDIAN_PER_ROW'
       doLinearize: False
       doCrosstalk: False
-      doDefect: False

--- a/pipelines/Latiss/cpFlat.yaml
+++ b/pipelines/Latiss/cpFlat.yaml
@@ -1,0 +1,45 @@
+description: obs_lsst/latiss flat calibration construction
+instrument: lsst.obs.lsst.Latiss
+# Do not inherit until defect/linearize/ct work
+# inherits:
+#   location: $CP_PIPE_DIR/pipelines/cpFlat.yaml
+tasks:
+  isr:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.outputExposure: 'cpFlatProc'
+      doBias: True
+      doVariance: True
+      doLinearize: False
+      doCrosstalk: False
+      doDefect: True
+      doNanMasking: True
+      doInterpolate: True
+      doDark: True
+      doBrighterFatter: False
+      doFlat: False
+      doFringe: False
+      doApplyGains: False
+  cpFlatMeasure:
+    class: lsst.cp.pipe.cpFlatNormTask.CpFlatMeasureTask
+    config:
+      connections.inputExp: 'cpFlatProc'
+      connections.outputStats: 'flatStats'
+      doVignette: False
+  cpFlatNorm:
+    class: lsst.cp.pipe.cpFlatNormTask.CpFlatNormalizationTask
+    config:
+      connections.inputMDs: 'flatStats'
+      connections.outputScales: 'cpFlatNormScales'
+  cpFlatCombine:
+    class: lsst.cp.pipe.cpCombine.CalibCombineByFilterTask
+    config:
+      connections.inputExps: 'cpFlatProc'
+      connections.inputScales: 'cpFlatNormScales'
+      connections.outputData: 'flat'
+      calibrationType: 'flat'
+      exposureScaling: InputList
+      scalingLevel: AMP
+contracts:
+  - isr.doFlat == False

--- a/pipelines/Latiss/cpFlat.yaml
+++ b/pipelines/Latiss/cpFlat.yaml
@@ -1,45 +1,12 @@
-description: obs_lsst/latiss flat calibration construction
+description: Latiss flat calibration construction
 instrument: lsst.obs.lsst.Latiss
-# Do not inherit until defect/linearize/ct work
-# inherits:
-#   location: $CP_PIPE_DIR/pipelines/cpFlat.yaml
+imports:
+  - location: $CP_PIPE_DIR/pipelines/cpFlatSingleChip.yaml
 tasks:
   isr:
     class: lsst.ip.isr.isrTask.IsrTask
     config:
-      connections.ccdExposure: 'raw'
-      connections.outputExposure: 'cpFlatProc'
-      doBias: True
-      doVariance: True
+      # Disable these until useful calibrations exist.
       doLinearize: False
       doCrosstalk: False
-      doDefect: True
-      doNanMasking: True
-      doInterpolate: True
-      doDark: True
-      doBrighterFatter: False
-      doFlat: False
-      doFringe: False
-      doApplyGains: False
-  cpFlatMeasure:
-    class: lsst.cp.pipe.cpFlatNormTask.CpFlatMeasureTask
-    config:
-      connections.inputExp: 'cpFlatProc'
-      connections.outputStats: 'flatStats'
-      doVignette: False
-  cpFlatNorm:
-    class: lsst.cp.pipe.cpFlatNormTask.CpFlatNormalizationTask
-    config:
-      connections.inputMDs: 'flatStats'
-      connections.outputScales: 'cpFlatNormScales'
-  cpFlatCombine:
-    class: lsst.cp.pipe.cpCombine.CalibCombineByFilterTask
-    config:
-      connections.inputExps: 'cpFlatProc'
-      connections.inputScales: 'cpFlatNormScales'
-      connections.outputData: 'flat'
-      calibrationType: 'flat'
-      exposureScaling: InputList
-      scalingLevel: AMP
-contracts:
-  - isr.doFlat == False
+      doDefect: False

--- a/pipelines/Latiss/cpFlat.yaml
+++ b/pipelines/Latiss/cpFlat.yaml
@@ -4,7 +4,7 @@ imports:
   - location: $CP_PIPE_DIR/pipelines/cpFlatSingleChip.yaml
 tasks:
   isr:
-    class: lsst.ip.isr.isrTask.IsrTask
+    class: lsst.ip.isr.IsrTask
     config:
       # Disable these until useful calibrations exist.
       doLinearize: False

--- a/pipelines/Latiss/cpFlat.yaml
+++ b/pipelines/Latiss/cpFlat.yaml
@@ -7,6 +7,7 @@ tasks:
     class: lsst.ip.isr.IsrTask
     config:
       # Disable these until useful calibrations exist.
+      overscan.fitType: 'MEDIAN_PER_ROW'
       doLinearize: False
       doCrosstalk: False
       doDefect: False

--- a/pipelines/Latiss/cpFringe.yaml
+++ b/pipelines/Latiss/cpFringe.yaml
@@ -1,0 +1,38 @@
+description: obs_lsst/latiss fringe calibration construction
+instrument: lsst.obs.lsst.Latiss
+# Do not inherit until defects/linearize/ct is fixed.
+# inherits:
+#   location: $CP_PIPE_DIR/pipelines/cpFringe.yaml
+tasks:
+  isr:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.outputExposure: 'cpFringeIsr'
+      doBias: True
+      doVariance: True
+      doLinearize: False
+      doCrosstalk: False
+      doDefect: False
+      doNanMasking: True
+      doInterpolate: True
+      doDark: True
+      doFlat: True
+      doApplyGains: False
+      doFringe: False
+  cpFringe:
+    class: lsst.cp.pipe.cpFringeTask.CpFringeTask
+    config:
+      connections.inputExp: 'cpFringeIsr'
+      connections.outputExp: 'cpFringeProc'
+  cpFringeCombine:
+    class: lsst.cp.pipe.cpCombine.CalibCombineByFilterTask
+    config:
+      connections.inputExps: 'cpFringeProc'
+      connections.outputData: 'fringe'
+      calibrationType: 'fringe'
+      exposureScaling: "Unity"
+contracts:
+  - isr.doFringe == False
+  - cpFringeCombine.calibrationType == "fringe"
+  - cpFringeCombine.exposureScaling == "Unity"

--- a/pipelines/Latiss/cpFringe.yaml
+++ b/pipelines/Latiss/cpFringe.yaml
@@ -1,38 +1,12 @@
-description: obs_lsst/latiss fringe calibration construction
+description: Latiss fringe calibration construction
 instrument: lsst.obs.lsst.Latiss
-# Do not inherit until defects/linearize/ct is fixed.
-# inherits:
-#   location: $CP_PIPE_DIR/pipelines/cpFringe.yaml
+imports:
+  - location: $CP_PIPE_DIR/pipelines/cpFringe.yaml
 tasks:
   isr:
     class: lsst.ip.isr.isrTask.IsrTask
     config:
-      connections.ccdExposure: 'raw'
-      connections.outputExposure: 'cpFringeIsr'
-      doBias: True
-      doVariance: True
+      # Disable these until useful calibrations exist.
       doLinearize: False
       doCrosstalk: False
       doDefect: False
-      doNanMasking: True
-      doInterpolate: True
-      doDark: True
-      doFlat: True
-      doApplyGains: False
-      doFringe: False
-  cpFringe:
-    class: lsst.cp.pipe.cpFringeTask.CpFringeTask
-    config:
-      connections.inputExp: 'cpFringeIsr'
-      connections.outputExp: 'cpFringeProc'
-  cpFringeCombine:
-    class: lsst.cp.pipe.cpCombine.CalibCombineByFilterTask
-    config:
-      connections.inputExps: 'cpFringeProc'
-      connections.outputData: 'fringe'
-      calibrationType: 'fringe'
-      exposureScaling: "Unity"
-contracts:
-  - isr.doFringe == False
-  - cpFringeCombine.calibrationType == "fringe"
-  - cpFringeCombine.exposureScaling == "Unity"

--- a/pipelines/Latiss/cpFringe.yaml
+++ b/pipelines/Latiss/cpFringe.yaml
@@ -7,6 +7,7 @@ tasks:
     class: lsst.ip.isr.IsrTask
     config:
       # Disable these until useful calibrations exist.
+      overscan.fitType: 'MEDIAN_PER_ROW'
       doLinearize: False
       doCrosstalk: False
       doDefect: False

--- a/pipelines/Latiss/cpFringe.yaml
+++ b/pipelines/Latiss/cpFringe.yaml
@@ -4,7 +4,7 @@ imports:
   - location: $CP_PIPE_DIR/pipelines/cpFringe.yaml
 tasks:
   isr:
-    class: lsst.ip.isr.isrTask.IsrTask
+    class: lsst.ip.isr.IsrTask
     config:
       # Disable these until useful calibrations exist.
       doLinearize: False

--- a/pipelines/Latiss/findDefects.yaml
+++ b/pipelines/Latiss/findDefects.yaml
@@ -1,4 +1,5 @@
 description: cp_pipe DEFECT calibration construction.
+instrument: lsst.obs.lsst.Latiss
 tasks:
   isr:
     class: lsst.ip.isr.IsrTask

--- a/pipelines/Latiss/findDefects.yaml
+++ b/pipelines/Latiss/findDefects.yaml
@@ -1,0 +1,34 @@
+description: cp_pipe DEFECT calibration construction.
+tasks:
+  isr:
+    class: lsst.ip.isr.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.outputExposure: 'cpDefectsProc'
+      overscan.fitType: 'MEDIAN_PER_ROW'
+      doWrite: True
+      doOverscan: True
+      doAssembleCcd: True
+      doBias: True
+      doVariance: False
+      doLinearize: False
+      doCrosstalk: False
+      doBrighterFatter: False
+      doDark: False
+      doStrayLight: False
+      doFlat: False
+      doFringe: False
+      doApplyGains: False
+      doDefect: False
+      doSaturationInterpolation: False
+      growSaturationFootprintSize: 0
+  measureDefects:
+    class: lsst.cp.pipe.defects.MeasureDefectsTask
+    config:
+      connections.inputExp: 'cpDefectsProc'
+      connections.outputDefects: 'cpPartialDefects'
+  mergeDefects:
+    class: lsst.cp.pipe.defects.MergeDefectsTask
+    config:
+      connections.inputDefects: 'cpPartialDefects'
+      connections.mergedDefects: 'defects'

--- a/pipelines/Latiss/findDefectsPostFlat.yaml
+++ b/pipelines/Latiss/findDefectsPostFlat.yaml
@@ -1,0 +1,34 @@
+description: cp_pipe DEFECT calibration construction.
+tasks:
+  isr:
+    class: lsst.ip.isr.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.outputExposure: 'cpDefectsProc'
+      overscan.fitType: 'MEDIAN_PER_ROW'
+      doWrite: True
+      doOverscan: True
+      doAssembleCcd: True
+      doBias: True
+      doVariance: False
+      doLinearize: False
+      doCrosstalk: False
+      doBrighterFatter: False
+      doDark: True
+      doStrayLight: False
+      doFlat: True
+      doFringe: False
+      doApplyGains: False
+      doDefect: False
+      doSaturationInterpolation: False
+      growSaturationFootprintSize: 0
+  measureDefects:
+    class: lsst.cp.pipe.defects.MeasureDefectsTask
+    config:
+      connections.inputExp: 'cpDefectsProc'
+      connections.outputDefects: 'cpPartialDefects'
+  mergeDefects:
+    class: lsst.cp.pipe.defects.MergeDefectsTask
+    config:
+      connections.inputDefects: 'cpPartialDefects'
+      connections.mergedDefects: 'defects'

--- a/pipelines/Latiss/findDefectsPostFlat.yaml
+++ b/pipelines/Latiss/findDefectsPostFlat.yaml
@@ -1,4 +1,5 @@
 description: cp_pipe DEFECT calibration construction.
+instrument: lsst.obs.lsst.Latiss
 tasks:
   isr:
     class: lsst.ip.isr.IsrTask

--- a/pipelines/Latiss/measurePtcWithLinearity.yaml
+++ b/pipelines/Latiss/measurePtcWithLinearity.yaml
@@ -1,0 +1,11 @@
+description: cp_pipe Photon-Transfer Curve calibration construction, with Linearity enabled on inputs.
+instrument: lsst.obs.lsst.Latiss
+imports:
+  - location: $CP_PIPE_DIR/pipelines/measurePhotonTransferCurve.yaml
+tasks:
+  isr:
+    class: lsst.ip.isr.IsrTask
+    config:
+      doLinearize: true
+  ptcExtract: lsst.cp.pipe.ptc.PhotonTransferCurveExtractTask
+  ptcSolve: lsst.cp.pipe.ptc.PhotonTransferCurveSolveTask

--- a/pipelines/LsstCamImSim/cpBfkSolve.yaml
+++ b/pipelines/LsstCamImSim/cpBfkSolve.yaml
@@ -1,9 +1,5 @@
-description: cp_pipe PTC calibration construction.
+description: ImSim brighter-fatter kernel construction.
 instrument: lsst.obs.lsst.LsstCamImSim
-tasks:
-  bfkSolve:
-    class: lsst.cp.pipe.BrighterFatterKernelSolveTask
-    config:
-#      connections.inputPTC: ptc
-      connections.outputBFK: bfk
+imports:
+  - location: $CP_PIPE_DIR/pipelines/cpBfkSolve.yaml
 

--- a/pipelines/LsstCamImSim/cpBfkSolve.yaml
+++ b/pipelines/LsstCamImSim/cpBfkSolve.yaml
@@ -1,0 +1,9 @@
+description: cp_pipe PTC calibration construction.
+instrument: lsst.obs.lsst.LsstCamImSim
+tasks:
+  bfkSolve:
+    class: lsst.cp.pipe.BrighterFatterKernelSolveTask
+    config:
+#      connections.inputPTC: ptc
+      connections.outputBFK: bfk
+

--- a/pipelines/LsstCamImSim/cpBias.yaml
+++ b/pipelines/LsstCamImSim/cpBias.yaml
@@ -1,0 +1,34 @@
+description: obs_lsst/latiss bias calibration construction
+instrument: lsst.obs.lsst.LsstCamImSim
+# Do not inherit until defect/linearize/ct work
+# inherits:
+#  location: $CP_PIPE_DIR/pipelines/cpBias.yaml
+tasks:
+  isr:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.outputExposure: 'cpBiasProc'
+      doBias: False
+      doVariance: True
+      doLinearize: False
+      doCrosstalk: False
+      doDefect: False
+      doNanMasking: True
+      doInterpolate: True
+      doBrighterFatter: False
+      doDark: False
+      doFlat: False
+      doApplyGains: False
+      doFringe: False
+  cpBiasCombine:
+    class: lsst.cp.pipe.cpCombine.CalibCombineTask
+    config:
+      connections.inputExps: 'cpBiasProc'
+      connections.outputData: 'bias'
+      calibrationType: 'bias'
+      exposureScaling: "Unity"
+contracts:
+  - isr.doBias == False
+  - cpBiasCombine.calibrationType == "bias"
+  - cpBiasCombine.exposureScaling == "Unity"

--- a/pipelines/LsstCamImSim/cpBias.yaml
+++ b/pipelines/LsstCamImSim/cpBias.yaml
@@ -4,6 +4,6 @@ imports:
  - location: $CP_PIPE_DIR/pipelines/cpBias.yaml
 tasks:
   isr:
-    class: lsst.ip.isr.isrTask.IsrTask
+    class: lsst.ip.isr.IsrTask
     config:
       doDefect: False

--- a/pipelines/LsstCamImSim/cpDark.yaml
+++ b/pipelines/LsstCamImSim/cpDark.yaml
@@ -1,0 +1,40 @@
+description: obs_lsst/latiss dark calibration construction
+instrument: lsst.obs.lsst.LsstCamImSim
+# Do not inherit until defect/linearize/ct work
+# inherits:
+#  location: $CP_PIPE_DIR/pipelines/cpDark.yaml
+tasks:
+  isr:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.outputExposure: 'cpDarkIsr'
+      doBias: True
+      doVariance: True
+      doLinearize: False
+      doCrosstalk: False
+      doDefect: False
+      doNanMasking: True
+      doInterpolate: True
+      doBrighterFatter: False
+      doDark: False
+      doFlat: False
+      doApplyGains: False
+      doFringe: False
+  cpDark:
+    class: lsst.cp.pipe.cpDarkTask.CpDarkTask
+    config:
+      connections.inputExp: 'cpDarkIsr'
+      connections.outputExp: 'cpDarkProc'
+  cpDarkCombine:
+    class: lsst.cp.pipe.cpCombine.CalibCombineTask
+    config:
+      connections.inputExps: 'cpDarkProc'
+      connections.outputData: 'dark'
+      calibrationType: 'dark'
+      exposureScaling: "DarkTime"
+      python: config.mask.append("CR")
+contracts:
+  - isr.doDark == False
+  - cpDarkCombine.calibrationType == "dark"
+  - cpDarkCombine.exposureScaling == "DarkTime"

--- a/pipelines/LsstCamImSim/cpDark.yaml
+++ b/pipelines/LsstCamImSim/cpDark.yaml
@@ -4,7 +4,7 @@ imports:
   - location: $CP_PIPE_DIR/pipelines/cpDark.yaml
 tasks:
   isr:
-    class: lsst.ip.isr.isrTask.IsrTask
+    class: lsst.ip.isr.IsrTask
     config:
       doLinearize: False
       doCrosstalk: False

--- a/pipelines/LsstCamImSim/cpFlat.yaml
+++ b/pipelines/LsstCamImSim/cpFlat.yaml
@@ -1,0 +1,45 @@
+description: obs_lsst/latiss flat calibration construction
+instrument: lsst.obs.lsst.LsstCamImSim
+# Do not inherit until defect/linearize/ct work
+# inherits:
+#   location: $CP_PIPE_DIR/pipelines/cpFlat.yaml
+tasks:
+  isr:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.outputExposure: 'cpFlatProc'
+      doBias: True
+      doVariance: True
+      doLinearize: False
+      doCrosstalk: False
+      doDefect: False
+      doNanMasking: True
+      doInterpolate: True
+      doDark: True
+      doBrighterFatter: False
+      doFlat: False
+      doFringe: False
+      doApplyGains: False
+  cpFlatMeasure:
+    class: lsst.cp.pipe.cpFlatNormTask.CpFlatMeasureTask
+    config:
+      connections.inputExp: 'cpFlatProc'
+      connections.outputStats: 'flatStats'
+      doVignette: False
+  cpFlatNorm:
+    class: lsst.cp.pipe.cpFlatNormTask.CpFlatNormalizationTask
+    config:
+      connections.inputMDs: 'flatStats'
+      connections.outputScales: 'cpFlatNormScales'
+  cpFlatCombine:
+    class: lsst.cp.pipe.cpCombine.CalibCombineByFilterTask
+    config:
+      connections.inputExps: 'cpFlatProc'
+      connections.inputScales: 'cpFlatNormScales'
+      connections.outputData: 'flat'
+      calibrationType: 'flat'
+      exposureScaling: InputList
+      scalingLevel: AMP
+contracts:
+  - isr.doFlat == False

--- a/pipelines/LsstCamImSim/cpFlat.yaml
+++ b/pipelines/LsstCamImSim/cpFlat.yaml
@@ -4,7 +4,7 @@ imports:
   - location: $CP_PIPE_DIR/pipelines/cpFlat.yaml
 tasks:
   isr:
-    class: lsst.ip.isr.isrTask.IsrTask
+    class: lsst.ip.isr.IsrTask
     config:
       doLinearize: False
       doCrosstalk: False

--- a/pipelines/LsstCamImSim/cpPtc.yaml
+++ b/pipelines/LsstCamImSim/cpPtc.yaml
@@ -4,7 +4,7 @@ imports:
   - location: $CP_PIPE_DIR/pipelines/measurePhotonTransferCurve.yaml
 tasks:
   isr:
-    class: lsst.ip.isr.isrTask.IsrTask
+    class: lsst.ip.isr.IsrTask
     config:
       doCrosstalk: False
       doDefect: False

--- a/pipelines/LsstCamImSim/cpPtc.yaml
+++ b/pipelines/LsstCamImSim/cpPtc.yaml
@@ -1,4 +1,4 @@
-description: ImSim PTC calibration construction.
+description: ImSim Photon-Transfer Curve calibration construction.
 instrument: lsst.obs.lsst.LsstCamImSim
 imports:
   - location: $CP_PIPE_DIR/pipelines/measurePhotonTransferCurve.yaml

--- a/pipelines/LsstCamImSim/cpPtc.yaml
+++ b/pipelines/LsstCamImSim/cpPtc.yaml
@@ -1,0 +1,50 @@
+description: cp_pipe PTC calibration construction.
+instrument: lsst.obs.lsst.LsstCamImSim
+parameters:
+    exposureName: cpPtcProc
+    measuredCovariances: cpCovariances
+tasks:
+  isr:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.ccdExposure: raw
+      connections.outputExposure: parameters.exposureName
+      doWrite: true
+      doOverscan: true
+      doAssembleCcd: true
+      doBias: true
+      doVariance: true
+      doLinearize: false
+      doCrosstalk: False
+      doBrighterFatter: false
+      doDark: true
+      doStrayLight: false
+      doFlat: true
+      doFringe: false
+      doApplyGains: false
+      doDefect: False
+      doNanMasking: true
+      doInterpolate: false
+      doSaturation: false
+      doSaturationInterpolation: false
+      growSaturationFootprintSize: 0
+  ptcExtract:
+    class: lsst.cp.pipe.ptc.PhotonTransferCurveExtractTask
+    config:
+      connections.inputExp: parameters.exposureName
+      connections.outputCovariances: parameters.measuredCovariances
+      matchByExposureId: True
+  ptcSolve:
+    class: lsst.cp.pipe.ptc.PhotonTransferCurveSolveTask
+    config:
+      connections.inputCovariances: parameters.measuredCovariances
+      connections.outputPtcDataset: ptc
+      ptcFitType: FULLCOVARIANCE
+      initialNonLinearityExclusionThresholdPositive: 0.999
+      initialNonLinearityExclusionThresholdNegative: 0.999
+      minVarPivotSearch: 250000
+      minMeanRatioTest: 150000
+      sigmaCutPtcOutliers: 10
+      sigmaClipFullFitCovariancesAstier: 10
+contracts:
+  - ptcSolve.maximumRangeCovariancesAstier == ptcExtract.maximumRangeCovariancesAstier

--- a/pipelines/LsstComCam/cpBias.yaml
+++ b/pipelines/LsstComCam/cpBias.yaml
@@ -1,5 +1,5 @@
-description: ImSim bias calibration construction
-instrument: lsst.obs.lsst.LsstCamImSim
+description: ComCam bias calibration construction
+instrument: lsst.obs.lsst.LsstComCam
 imports:
  - location: $CP_PIPE_DIR/pipelines/cpBias.yaml
 tasks:

--- a/pipelines/LsstComCam/cpBias.yaml
+++ b/pipelines/LsstComCam/cpBias.yaml
@@ -4,6 +4,6 @@ imports:
  - location: $CP_PIPE_DIR/pipelines/cpBias.yaml
 tasks:
   isr:
-    class: lsst.ip.isr.isrTask.IsrTask
+    class: lsst.ip.isr.IsrTask
     config:
       doDefect: False

--- a/pipelines/LsstComCam/cpDark.yaml
+++ b/pipelines/LsstComCam/cpDark.yaml
@@ -1,5 +1,5 @@
-description: ImSim dark calibration construction
-instrument: lsst.obs.lsst.LsstCamImSim
+description: ComCam dark calibration construction
+instrument: lsst.obs.lsst.LsstComCam
 imports:
   - location: $CP_PIPE_DIR/pipelines/cpDark.yaml
 tasks:

--- a/pipelines/LsstComCam/cpDark.yaml
+++ b/pipelines/LsstComCam/cpDark.yaml
@@ -4,7 +4,7 @@ imports:
   - location: $CP_PIPE_DIR/pipelines/cpDark.yaml
 tasks:
   isr:
-    class: lsst.ip.isr.isrTask.IsrTask
+    class: lsst.ip.isr.IsrTask
     config:
       doLinearize: False
       doCrosstalk: False

--- a/pipelines/LsstComCam/cpFlat.yaml
+++ b/pipelines/LsstComCam/cpFlat.yaml
@@ -4,7 +4,7 @@ imports:
   - location: $CP_PIPE_DIR/pipelines/cpFlat.yaml
 tasks:
   isr:
-    class: lsst.ip.isr.isrTask.IsrTask
+    class: lsst.ip.isr.IsrTask
     config:
       doLinearize: False
       doCrosstalk: False

--- a/pipelines/LsstComCam/cpFlat.yaml
+++ b/pipelines/LsstComCam/cpFlat.yaml
@@ -1,5 +1,5 @@
-description: ImSim flat calibration construction
-instrument: lsst.obs.lsst.LsstCamImSim
+description: ComCam flat calibration construction
+instrument: lsst.obs.lsst.LsstComCam
 imports:
   - location: $CP_PIPE_DIR/pipelines/cpFlat.yaml
 tasks:

--- a/pipelines/LsstComCam/cpPtc.yaml
+++ b/pipelines/LsstComCam/cpPtc.yaml
@@ -4,7 +4,7 @@ imports:
   - location: $CP_PIPE_DIR/pipelines/measurePhotonTransferCurve.yaml
 tasks:
   isr:
-    class: lsst.ip.isr.isrTask.IsrTask
+    class: lsst.ip.isr.IsrTask
     config:
       doCrosstalk: False
       doDefect: False

--- a/pipelines/LsstComCam/cpPtc.yaml
+++ b/pipelines/LsstComCam/cpPtc.yaml
@@ -1,5 +1,5 @@
-description: ImSim PTC calibration construction.
-instrument: lsst.obs.lsst.LsstCamImSim
+description: ComCam PTC calibration construction.
+instrument: lsst.obs.lsst.LsstComCam
 imports:
   - location: $CP_PIPE_DIR/pipelines/measurePhotonTransferCurve.yaml
 tasks:
@@ -15,10 +15,4 @@ tasks:
   ptcSolve:
     class: lsst.cp.pipe.ptc.PhotonTransferCurveSolveTask
     config:
-      ptcFitType: FULLCOVARIANCE
-      initialNonLinearityExclusionThresholdPositive: 0.999
-      initialNonLinearityExclusionThresholdNegative: 0.999
-      minVarPivotSearch: 250000
-      minMeanRatioTest: 150000
-      sigmaCutPtcOutliers: 10
-      sigmaClipFullFitCovariancesAstier: 10
+      ptcFitType: EXPAPPROXIMATION

--- a/pipelines/LsstComCam/cpPtc.yaml
+++ b/pipelines/LsstComCam/cpPtc.yaml
@@ -1,4 +1,4 @@
-description: ComCam PTC calibration construction.
+description: ComCam Photon-Transfer Curve calibration construction.
 instrument: lsst.obs.lsst.LsstComCam
 imports:
   - location: $CP_PIPE_DIR/pipelines/measurePhotonTransferCurve.yaml


### PR DESCRIPTION
Add per-camera pipeline definitions that inherit from the base definitions.