### PR TITLE
DM-31545: Fix cp_pipe/defects debug error

### DIFF
--- a/python/lsst/cp/pipe/defects.py
+++ b/python/lsst/cp/pipe/defects.py
@@ -528,7 +528,7 @@ class MeasureDefectsTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                     import pdb
                     pdb.set_trace()
                 elif ans in ("h", ):
-                    print("[h]elp [c]ontinue [p]db e[x]itDebug")
+                    print("[h]elp [c]ontinue [p]db")
             plt.close()
 
 

--- a/python/lsst/cp/pipe/defects.py
+++ b/python/lsst/cp/pipe/defects.py
@@ -467,7 +467,7 @@ class MeasureDefectsTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
             detector = exp.getDetector()
             nX = np.floor(np.sqrt(len(detector)))
             nY = len(detector) // nX
-            fig, ax = plt.subplots(nrows=nY, ncols=nX, sharex='col', sharey='row', figsize=(13, 10))
+            fig, ax = plt.subplots(nrows=int(nY), ncols=int(nX), sharex='col', sharey='row', figsize=(13, 10))
 
             expTime = exp.getInfo().getVisitInfo().getExposureTime()
 
@@ -518,7 +518,18 @@ class MeasureDefectsTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                 a.set_xlim(np.array([lPlot, rPlot]))
                 a.set_yscale('log')
                 a.set_xlabel("ADU/s")
-        return
+            fig.show()
+            prompt = "Press Enter or c to continue [chp]..."
+            while True:
+                ans = input(prompt).lower()
+                if ans in ("", " ", "c",):
+                    break
+                elif ans in ("p", ):
+                    import pdb
+                    pdb.set_trace()
+                elif ans in ("h", ):
+                    print("[h]elp [c]ontinue [p]db e[x]itDebug")
+            plt.close()
 
 
 class MergeDefectsConnections(pipeBase.PipelineTaskConnections,

--- a/python/lsst/cp/pipe/ptc/cpExtractPtcTask.py
+++ b/python/lsst/cp/pipe/ptc/cpExtractPtcTask.py
@@ -303,7 +303,7 @@ class PhotonTransferCurveExtractTask(pipeBase.PipelineTask,
                                   maskPlane="SUSPECT", level=self.config.edgeMaskLevel)
 
             nAmpsNan = 0
-            partialPtcDataset = PhotonTransferCurveDataset(ampNames, '',
+            partialPtcDataset = PhotonTransferCurveDataset(ampNames, 'PARTIAL',
                                                            self.config.maximumRangeCovariancesAstier)
             for ampNumber, amp in enumerate(detector):
                 ampName = amp.getName()


### PR DESCRIPTION
This also fixes the underlying issue that was causing Jenkins to fail: an empty string in the PTC_FIT_TYPE now throws an error on read.  I've fixed that (it now sets the field to PARTIAL in the covariance outputs), and will check that this passes before merging.