### PR TITLE
DM-13943: Deprecate VisitInfo.getExposureId()

### DIFF
--- a/python/lsst/cp/pipe/cpCombine.py
+++ b/python/lsst/cp/pipe/cpCombine.py
@@ -275,7 +275,7 @@ class CalibCombineTask(pipeBase.PipelineTask,
         # on detId), or that no inputs have any detector.
         detectorList = [exp.getDetector() for exp in inputExps]
         if None in detectorList:
-            self.log.warn("Not all input detectors defined.")
+            self.log.warning("Not all input detectors defined.")
         detectorIds = [det.getId() if det is not None else None for det in detectorList]
         detectorSerials = [det.getId() if det is not None else None for det in detectorList]
         numDetectorIds = len(set(detectorIds))
@@ -298,7 +298,7 @@ class CalibCombineTask(pipeBase.PipelineTask,
         for index, (exp, dims) in enumerate(zip(inputExps, inputDims)):
             scale = 1.0
             if exp is None:
-                self.log.warn("Input %d is None (%s); unable to scale exp.", index, dims)
+                self.log.warning("Input %d is None (%s); unable to scale exp.", index, dims)
                 continue
 
             if self.config.exposureScaling == "ExposureTime":
@@ -500,7 +500,7 @@ class CalibCombineTask(pipeBase.PipelineTask,
         try:
             group = ObservationGroup(visitInfoList, pedantic=False)
         except Exception:
-            self.log.warn("Exception making an obs group for headers. Continuing.")
+            self.log.warning("Exception making an obs group for headers. Continuing.")
             # Fall back to setting a DATE-OBS from the calibDate
             dateCards = {"DATE-OBS": "{}T00:00:00.00".format(calibDate)}
             comments["DATE-OBS"] = "Date of start of day of calibration midpoint"
@@ -532,7 +532,7 @@ class CalibCombineTask(pipeBase.PipelineTask,
         count = np.sum(np.logical_not(bad))
         array[bad] = median
         if count > 0:
-            self.log.warn("Found %s NAN pixels", count)
+            self.log.warning("Found %s NAN pixels", count)
 
 
 # Create versions of the Connections, Config, and Task that support

--- a/python/lsst/cp/pipe/cpCombine.py
+++ b/python/lsst/cp/pipe/cpCombine.py
@@ -487,7 +487,7 @@ class CalibCombineTask(pipeBase.PipelineTask,
         for i, visit in enumerate(visitInfoList):
             if visit is None:
                 continue
-            header.set("CPP_INPUT_%d" % (i,), visit.getExposureId())
+            header.set("CPP_INPUT_%d" % (i,), visit.id)
             header.set("CPP_INPUT_DATE_%d" % (i,), str(visit.getDate()))
             header.set("CPP_INPUT_EXPT_%d" % (i,), visit.getExposureTime())
             if scales is not None:

--- a/python/lsst/cp/pipe/cpSkyTask.py
+++ b/python/lsst/cp/pipe/cpSkyTask.py
@@ -146,7 +146,7 @@ class CpSkyImageTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
         currentMask = inputExp.getMask()
         badMask = currentMask.getPlaneBitMask(self.config.maskList)
         if (currentMask.getArray() & badMask).all():
-            self.log.warn("All pixels are masked!")
+            self.log.warning("All pixels are masked!")
         else:
             self.maskTask.run(inputExp, self.config.maskList)
 

--- a/python/lsst/cp/pipe/linearity.py
+++ b/python/lsst/cp/pipe/linearity.py
@@ -193,7 +193,7 @@ class LinearitySolveTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
         they are not included in the non-linearity correction.
         """
         if len(dummy) == 0:
-            self.log.warn("No dummy exposure found.")
+            self.log.warning("No dummy exposure found.")
 
         detector = camera[inputDims['detector']]
         if self.config.linearityType == 'LookupTable':
@@ -234,11 +234,11 @@ class LinearitySolveTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                 linearizer.fitParams[ampName] = np.zeros(pEntries)
                 linearizer.fitParamsErr[ampName] = np.zeros(pEntries)
                 linearizer.fitChiSq[ampName] = np.nan
-                self.log.warn("Amp %s has no usable PTC information.  Skipping!", ampName)
+                self.log.warning("Amp %s has no usable PTC information.  Skipping!", ampName)
                 continue
 
             if (len(inputPtc.expIdMask[ampName]) == 0) or self.config.ignorePtcMask:
-                self.log.warn(f"Mask not found for {ampName} in non-linearity fit. Using all points.")
+                self.log.warning(f"Mask not found for {ampName} in non-linearity fit. Using all points.")
                 mask = np.repeat(True, len(inputPtc.expIdMask[ampName]))
             else:
                 mask = np.array(inputPtc.expIdMask[ampName], dtype=bool)

--- a/python/lsst/cp/pipe/makeBrighterFatterKernel.py
+++ b/python/lsst/cp/pipe/makeBrighterFatterKernel.py
@@ -193,7 +193,7 @@ class BrighterFatterKernelSolveTask(pipeBase.PipelineTask, pipeBase.CmdLineTask)
                 (`lsst.ip.isr.BrighterFatterKernel`).
         """
         if len(dummy) == 0:
-            self.log.warn("No dummy exposure found.")
+            self.log.warning("No dummy exposure found.")
 
         detector = camera[inputDims['detector']]
         detName = detector.getName()
@@ -235,8 +235,8 @@ class BrighterFatterKernelSolveTask(pipeBase.PipelineTask, pipeBase.CmdLineTask)
 
             if gain <= 0:
                 # We've received very bad data.
-                self.log.warn("Impossible gain recieved from PTC for %s: %f.  Skipping amplifier.",
-                              ampName, gain)
+                self.log.warning("Impossible gain recieved from PTC for %s: %f.  Skipping amplifier.",
+                                 ampName, gain)
                 bfk.meanXcorrs[ampName] = np.zeros(bfk.shape)
                 bfk.ampKernels[ampName] = np.zeros(bfk.shape)
                 bfk.valid[ampName] = False
@@ -261,8 +261,8 @@ class BrighterFatterKernelSolveTask(pipeBase.PipelineTask, pipeBase.CmdLineTask)
                 q[0][0] -= 2.0*(flux)
 
                 if q[0][0] > 0.0:
-                    self.log.warn("Amp: %s %d skipped due to value of (variance-mean)=%f",
-                                  ampName, xcorrNum, q[0][0])
+                    self.log.warning("Amp: %s %d skipped due to value of (variance-mean)=%f",
+                                     ampName, xcorrNum, q[0][0])
                     continue
 
                 # This removes the "t (I_a^2 + I_b^2)" factor in
@@ -272,8 +272,8 @@ class BrighterFatterKernelSolveTask(pipeBase.PipelineTask, pipeBase.CmdLineTask)
 
                 xcorrCheck = np.abs(np.sum(scaled))/np.sum(np.abs(scaled))
                 if (xcorrCheck > self.config.xcorrCheckRejectLevel) or not (np.isfinite(xcorrCheck)):
-                    self.log.warn("Amp: %s %d skipped due to value of triangle-inequality sum %f",
-                                  ampName, xcorrNum, xcorrCheck)
+                    self.log.warning("Amp: %s %d skipped due to value of triangle-inequality sum %f",
+                                     ampName, xcorrNum, xcorrCheck)
                     continue
 
                 scaledCorrList.append(scaled)
@@ -281,7 +281,7 @@ class BrighterFatterKernelSolveTask(pipeBase.PipelineTask, pipeBase.CmdLineTask)
                               ampName, xcorrNum, len(xCorrList), q[0][0], xcorrCheck)
 
             if len(scaledCorrList) == 0:
-                self.log.warn("Amp: %s All inputs rejected for amp!", ampName)
+                self.log.warning("Amp: %s All inputs rejected for amp!", ampName)
                 bfk.meanXcorrs[ampName] = np.zeros(bfk.shape)
                 bfk.ampKernels[ampName] = np.zeros(bfk.shape)
                 bfk.valid[ampName] = False
@@ -525,8 +525,8 @@ class BrighterFatterKernelSolveTask(pipeBase.PipelineTask, pipeBase.CmdLineTask)
             nIter += 1
 
         if nIter >= maxIter*2:
-            self.log.warn("Failure: SuccessiveOverRelaxation did not converge in %s iterations."
-                          "\noutError: %s, inError: %s," % (nIter//2, outError, inError*eLevel))
+            self.log.warning("Failure: SuccessiveOverRelaxation did not converge in %s iterations."
+                             "\noutError: %s, inError: %s," % (nIter//2, outError, inError*eLevel))
         else:
             self.log.info("Success: SuccessiveOverRelaxation converged in %s iterations."
                           "\noutError: %s, inError: %s", nIter//2, outError, inError*eLevel)

--- a/python/lsst/cp/pipe/measureCrosstalk.py
+++ b/python/lsst/cp/pipe/measureCrosstalk.py
@@ -568,7 +568,7 @@ class CrosstalkSolveTask(pipeBase.PipelineTask,
             calib.coeffNum[ii][jj] = len(values)
 
             if len(values) == 0:
-                self.log.warn("No values for matrix element %d,%d" % (ii, jj))
+                self.log.warning("No values for matrix element %d,%d" % (ii, jj))
                 calib.coeffs[ii][jj] = np.nan
                 calib.coeffErr[ii][jj] = np.nan
                 calib.coeffValid[ii][jj] = False

--- a/python/lsst/cp/pipe/ptc/cpExtractPtcTask.py
+++ b/python/lsst/cp/pipe/ptc/cpExtractPtcTask.py
@@ -283,8 +283,8 @@ class PhotonTransferCurveExtractTask(pipeBase.PipelineTask,
         for expTime in inputExp:
             exposures = inputExp[expTime]
             if len(exposures) == 1:
-                self.log.warn(f"Only one exposure found at expTime {expTime}. Dropping exposure "
-                              f"{exposures[0][1]}")
+                self.log.warning(f"Only one exposure found at expTime {expTime}. Dropping exposure "
+                                 f"{exposures[0][1]}")
                 continue
             else:
                 # Only use the first two exposures at expTime. Each
@@ -292,9 +292,9 @@ class PhotonTransferCurveExtractTask(pipeBase.PipelineTask,
                 exp1, expId1 = exposures[0]
                 exp2, expId2 = exposures[1]
                 if len(exposures) > 2:
-                    self.log.warn(f"Already found 2 exposures at expTime {expTime}. "
-                                  "Ignoring exposures: "
-                                  f"{i[1] for i in exposures[2:]}")
+                    self.log.warning(f"Already found 2 exposures at expTime {expTime}. "
+                                     "Ignoring exposures: "
+                                     f"{i[1] for i in exposures[2:]}")
             # Mask pixels at the edge of the detector or of each amp
             if self.config.numEdgeSuspect > 0:
                 isrTask.maskEdges(exp1, numEdgePixels=self.config.numEdgeSuspect,
@@ -333,7 +333,7 @@ class PhotonTransferCurveExtractTask(pipeBase.PipelineTask,
                 if np.isnan(muDiff) or np.isnan(varDiff) or (covAstier is None):
                     msg = (f"NaN mean or var, or None cov in amp {ampName} in exposure pair {expId1},"
                            f" {expId2} of detector {detNum}.")
-                    self.log.warn(msg)
+                    self.log.warning(msg)
                     nAmpsNan += 1
                     expIdMask = False
                     covArray = np.full((1, self.config.maximumRangeCovariancesAstier,
@@ -371,7 +371,7 @@ class PhotonTransferCurveExtractTask(pipeBase.PipelineTask,
 
             if nAmpsNan == len(ampNames):
                 msg = f"NaN mean in all amps of exposure pair {expId1}, {expId2} of detector {detNum}."
-                self.log.warn(msg)
+                self.log.warning(msg)
         return pipeBase.Struct(
             outputCovariances=partialPtcDatasetList,
         )
@@ -451,7 +451,7 @@ class PhotonTransferCurveExtractTask(pipeBase.PipelineTask,
         mu1 = afwMath.makeStatistics(im1Area, afwMath.MEANCLIP, im1StatsCtrl).getValue()
         mu2 = afwMath.makeStatistics(im2Area, afwMath.MEANCLIP, im2StatsCtrl).getValue()
         if np.isnan(mu1) or np.isnan(mu2):
-            self.log.warn(f"Mean of amp in image 1 or 2 is NaN: {mu1}, {mu2}.")
+            self.log.warning(f"Mean of amp in image 1 or 2 is NaN: {mu1}, {mu2}.")
             return np.nan, np.nan, None
         mu = 0.5*(mu1 + mu2)
 
@@ -490,8 +490,8 @@ class PhotonTransferCurveExtractTask(pipeBase.PipelineTask,
         w = unmasked*wDiff
 
         if np.sum(w) < self.config.minNumberGoodPixelsForCovariance:
-            self.log.warn(f"Number of good points for covariance calculation ({np.sum(w)}) is less "
-                          f"(than threshold {self.config.minNumberGoodPixelsForCovariance})")
+            self.log.warning(f"Number of good points for covariance calculation ({np.sum(w)}) is less "
+                             f"(than threshold {self.config.minNumberGoodPixelsForCovariance})")
             return np.nan, np.nan, None
 
         maxRangeCov = self.config.maximumRangeCovariancesAstier
@@ -516,7 +516,7 @@ class PhotonTransferCurveExtractTask(pipeBase.PipelineTask,
         thresholdPercentage = self.config.thresholdDiffAfwVarVsCov00
         fractionalDiff = 100*np.fabs(1 - varDiff/(covDiffAstier[0][3]*0.5))
         if fractionalDiff >= thresholdPercentage:
-            self.log.warn("Absolute fractional difference between afwMatch.VARIANCECLIP and Cov[0,0] "
-                          f"is more than {thresholdPercentage}%: {fractionalDiff}")
+            self.log.warning("Absolute fractional difference between afwMatch.VARIANCECLIP and Cov[0,0] "
+                             f"is more than {thresholdPercentage}%: {fractionalDiff}")
 
         return mu, varDiff, covDiffAstier

--- a/python/lsst/cp/pipe/ptc/cpSolvePtcTask.py
+++ b/python/lsst/cp/pipe/ptc/cpSolvePtcTask.py
@@ -503,7 +503,7 @@ class PhotonTransferCurveSolveTask(pipeBase.PipelineTask,
         index, = np.where(array == 0)
         if len(index):
             msg = f"Found {nBad} zeros in array at elements {index}"
-            self.log.warn(msg)
+            self.log.warning(msg)
 
         array[index] = substituteValue
 
@@ -583,7 +583,7 @@ class PhotonTransferCurveSolveTask(pipeBase.PipelineTask,
             if not (goodPoints.any()):
                 msg = (f"SERIOUS: All points in goodPoints: {goodPoints} are bad."
                        f"Setting {ampName} to BAD.")
-                self.log.warn(msg)
+                self.log.warning(msg)
                 # Fill entries with NaNs
                 self.fillBadAmp(dataset, ptcFitType, ampName)
                 continue
@@ -623,7 +623,7 @@ class PhotonTransferCurveSolveTask(pipeBase.PipelineTask,
                 if not (mask.any() and newMask.any()):
                     msg = (f"SERIOUS: All points in either mask: {mask} or newMask: {newMask} are bad. "
                            f"Setting {ampName} to BAD.")
-                    self.log.warn(msg)
+                    self.log.warning(msg)
                     # Fill entries with NaNs
                     self.fillBadAmp(dataset, ptcFitType, ampName)
                     break
@@ -651,7 +651,7 @@ class PhotonTransferCurveSolveTask(pipeBase.PipelineTask,
             if (len(meanVecFinal) < len(parsIniPtc)):
                 msg = (f"SERIOUS: Not enough data points ({len(meanVecFinal)}) compared to the number of "
                        f"parameters of the PTC model({len(parsIniPtc)}). Setting {ampName} to BAD.")
-                self.log.warn(msg)
+                self.log.warning(msg)
                 # Fill entries with NaNs
                 self.fillBadAmp(dataset, ptcFitType, ampName)
                 continue

--- a/python/lsst/cp/pipe/ptc/measurePtcGen2Task.py
+++ b/python/lsst/cp/pipe/ptc/measurePtcGen2Task.py
@@ -124,7 +124,7 @@ class MeasurePhotonTransferCurveTask(pipeBase.CmdLineTask):
                 self.log.warn("postISR exposure could not be retrieved. Ignoring flat.")
                 continue
             expList.append(tempFlat)
-        expIds = [exp.getInfo().getVisitInfo().getExposureId() for exp in expList]
+        expIds = [exp.info.getVisitInfo().id for exp in expList]
 
         # Create dictionary of exposures, keyed by exposure time
         expDict = arrangeFlatsByExpTime(expList)

--- a/python/lsst/cp/pipe/ptc/measurePtcGen2Task.py
+++ b/python/lsst/cp/pipe/ptc/measurePtcGen2Task.py
@@ -121,7 +121,7 @@ class MeasurePhotonTransferCurveTask(pipeBase.CmdLineTask):
             try:
                 tempFlat = dataRef.get("postISRCCD")
             except RuntimeError:
-                self.log.warn("postISR exposure could not be retrieved. Ignoring flat.")
+                self.log.warning("postISR exposure could not be retrieved. Ignoring flat.")
                 continue
             expList.append(tempFlat)
         expIds = [exp.info.getVisitInfo().id for exp in expList]

--- a/python/lsst/cp/pipe/utils.py
+++ b/python/lsst/cp/pipe/utils.py
@@ -687,8 +687,6 @@ def arrangeFlatsByExpId(exposureList, exposureIdList):
     populated pairs.
     """
     flatsAtExpId = {}
-    # sortedExposures = sorted(exposureList, key=lambda exp:
-    # exp.getInfo().getVisitInfo().getExposureId())
     assert len(exposureList) == len(exposureIdList), "Different lengths for exp. list and exp. ID lists"
     # Sort exposures by expIds, which are in the second list `exposureIdList`.
     sortedExposures = sorted(zip(exposureList, exposureIdList), key=lambda pair: pair[1])

--- a/python/lsst/cp/pipe/utils.py
+++ b/python/lsst/cp/pipe/utils.py
@@ -347,7 +347,7 @@ class NonexistentDatasetTaskDataIdContainer(pipeBase.DataIdContainer):
             # exclude nonexistent data
             # this is a recursive test, e.g. for the sake of "raw" data
             if not refList:
-                namespace.log.warn("No data found for dataId=%s", dataId)
+                namespace.log.warning("No data found for dataId=%s", dataId)
                 continue
             self.refList += refList
 
@@ -812,9 +812,9 @@ def validateIsrConfig(isrTask, mandatory=None, forbidden=None, desirable=None, u
     if forbidden:
         for configParam in forbidden:
             if configParam not in configDict:
-                log.warn(f"Failed to find forbidden key {configParam} in the isr config. The keys in the"
-                         " forbidden list should each have an associated Field in IsrConfig:"
-                         " check that there is not a typo in this case.")
+                log.warning(f"Failed to find forbidden key {configParam} in the isr config. The keys in the"
+                            " forbidden list should each have an associated Field in IsrConfig:"
+                            " check that there is not a typo in this case.")
                 continue
             if configDict[configParam] is True:
                 raise RuntimeError(f"Must set config.isr.{configParam} to False for this task.")
@@ -826,8 +826,8 @@ def validateIsrConfig(isrTask, mandatory=None, forbidden=None, desirable=None, u
                          " to set the equivalent for your obs_package to True.")
                 continue
             if configDict[configParam] is False:
-                log.warn(f"Found config.isr.{configParam} set to False for this task."
-                         " The cp_pipe Config recommends setting this to True.")
+                log.warning(f"Found config.isr.{configParam} set to False for this task."
+                            " The cp_pipe Config recommends setting this to True.")
     if undesirable:
         for configParam in undesirable:
             if configParam not in configDict:
@@ -835,8 +835,8 @@ def validateIsrConfig(isrTask, mandatory=None, forbidden=None, desirable=None, u
                          " to set the equivalent for your obs_package to False.")
                 continue
             if configDict[configParam] is True:
-                log.warn(f"Found config.isr.{configParam} set to True for this task."
-                         " The cp_pipe Config recommends setting this to False.")
+                log.warning(f"Found config.isr.{configParam} set to True for this task."
+                            " The cp_pipe Config recommends setting this to False.")
 
     if checkTrim:  # subtask setting, seems non-trivial to combine with above lists
         if not isrTask.assembleCcd.config.doTrim:


### PR DESCRIPTION
This PR removes uses of `VisitInfo.getExposureId()`, which was deprecated in lsst/afw#614.