### PR TITLE
DM-31986: "filter label mismatch" on loading cp_pipe calibration

### DIFF
--- a/python/lsst/cp/pipe/cpCombine.py
+++ b/python/lsst/cp/pipe/cpCombine.py
@@ -347,7 +347,7 @@ class CalibCombineTask(pipeBase.PipelineTask,
 
         # Do we need to set a filter?
         filterLabel = inputExpHandles[0].get(component="filterLabel")
-        self.setFilterLabel(combinedExp, filterLabel)
+        self.setFilter(combinedExp, filterLabel)
 
         # Return
         return pipeBase.Struct(
@@ -582,7 +582,7 @@ class CalibCombineTask(pipeBase.PipelineTask,
             self.log.warning("Found and fixed %s NAN pixels", count)
 
     @staticmethod
-    def setFilterLabel(exp, filterLabel):
+    def setFilter(exp, filterLabel):
         """Dummy function that will not assign a filter.
 
         Parameters
@@ -634,7 +634,7 @@ class CalibCombineByFilterTask(CalibCombineTask):
     _DefaultName = "cpFilterCombine"
 
     @staticmethod
-    def setFilterLabel(exp, filterLabel):
+    def setFilter(exp, filterLabel):
         """Dummy function that will not assign a filter.
 
         Parameters
@@ -645,4 +645,4 @@ class CalibCombineByFilterTask(CalibCombineTask):
             Filter to assign.
         """
         if filterLabel:
-            exp.setFilterLabel(filterLabel)
+            exp.setFilter(filterLabel)

--- a/python/lsst/cp/pipe/cpCombine.py
+++ b/python/lsst/cp/pipe/cpCombine.py
@@ -345,6 +345,10 @@ class CalibCombineTask(pipeBase.PipelineTask,
         # Set the detector
         combinedExp.setDetector(inputDetector)
 
+        # Do we need to set a filter?
+        filterLabel = inputExpHandles[0].get(component="filterLabel")
+        self.setFilterLabel(combinedExp, filterLabel)
+
         # Return
         return pipeBase.Struct(
             outputData=combinedExp,
@@ -577,6 +581,19 @@ class CalibCombineTask(pipeBase.PipelineTask,
             array[bad] = median
             self.log.warning("Found and fixed %s NAN pixels", count)
 
+    @staticmethod
+    def setFilterLabel(exp, filterLabel):
+        """Dummy function that will not assign a filter.
+
+        Parameters
+        ----------
+        exp : `lsst.afw.image.Exposure`
+            Exposure to assign filter to.
+        filterLabel : `lsst.afw.image.FilterLabel`
+            Filter to assign.
+        """
+        pass
+
 
 # Create versions of the Connections, Config, and Task that support
 # filter constraints.
@@ -615,4 +632,17 @@ class CalibCombineByFilterTask(CalibCombineTask):
 
     ConfigClass = CalibCombineByFilterConfig
     _DefaultName = "cpFilterCombine"
-    pass
+
+    @staticmethod
+    def setFilterLabel(exp, filterLabel):
+        """Dummy function that will not assign a filter.
+
+        Parameters
+        ----------
+        exp : `lsst.afw.image.Exposure`
+            Exposure to assign filter to.
+        filterLabel : `lsst.afw.image.FilterLabel`
+            Filter to assign.
+        """
+        if filterLabel:
+            exp.setFilterLabel(filterLabel)

--- a/python/lsst/cp/pipe/cpSkyTask.py
+++ b/python/lsst/cp/pipe/cpSkyTask.py
@@ -412,7 +412,7 @@ class CpSkyCombineTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
         """
         skyCalib = self.sky.averageBackgrounds(inputBkgs)
         skyCalib.setDetector(inputExpHandles[0].get(component='detector'))
-        skyCalib.setFilterLabel(inputExpHandles[0].get(component='filterLabel'))
+        skyCalib.setFilter(inputExpHandles[0].get(component='filterLabel'))
 
         CalibCombineTask().combineHeaders(inputExpHandles, skyCalib, calibType='SKY')
 

--- a/python/lsst/cp/pipe/cpSkyTask.py
+++ b/python/lsst/cp/pipe/cpSkyTask.py
@@ -412,6 +412,7 @@ class CpSkyCombineTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
         """
         skyCalib = self.sky.averageBackgrounds(inputBkgs)
         skyCalib.setDetector(inputExpHandles[0].get(component='detector'))
+        skyCalib.setFilterLabel(inputExpHandles[0].get(component='filterLabel'))
 
         CalibCombineTask().combineHeaders(inputExpHandles, skyCalib, calibType='SKY')
 


### PR DESCRIPTION
Add method to set the filter label, which should reduce log noise.