### PR TITLE
DM-27177: Deprecate transitional getFilterLabel API

### DIFF
--- a/python/lsst/cp/pipe/defects.py
+++ b/python/lsst/cp/pipe/defects.py
@@ -153,7 +153,7 @@ class MeasureDefectsTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
         """
         detector = inputExp.getDetector()
 
-        filterName = inputExp.getFilterLabel().physicalLabel
+        filterName = inputExp.getFilter().physicalLabel
         datasetType = inputExp.getMetadata().get('IMGTYPE', 'UNKNOWN')
 
         if datasetType.lower() == 'dark':


### PR DESCRIPTION
This PR removes references to `getFilterLabel` and similarly-named methods, replacing them with `getFilter` (etc.) methods backed by `FilterLabel`.