### PR TITLE
DM-36507: Remove references to filterLabel component from cp_pipe

### DIFF
--- a/python/lsst/cp/pipe/cpCombine.py
+++ b/python/lsst/cp/pipe/cpCombine.py
@@ -345,7 +345,7 @@ class CalibCombineTask(pipeBase.PipelineTask):
         combinedExp.setDetector(inputDetector)
 
         # Do we need to set a filter?
-        filterLabel = inputExpHandles[0].get(component="filterLabel")
+        filterLabel = inputExpHandles[0].get(component="filter")
         self.setFilter(combinedExp, filterLabel)
 
         # Return

--- a/python/lsst/cp/pipe/cpSkyTask.py
+++ b/python/lsst/cp/pipe/cpSkyTask.py
@@ -412,7 +412,7 @@ class CpSkyCombineTask(pipeBase.PipelineTask):
         """
         skyCalib = self.sky.averageBackgrounds(inputBkgs)
         skyCalib.setDetector(inputExpHandles[0].get(component='detector'))
-        skyCalib.setFilter(inputExpHandles[0].get(component='filterLabel'))
+        skyCalib.setFilter(inputExpHandles[0].get(component='filter'))
 
         CalibCombineTask().combineHeaders(inputExpHandles, skyCalib, calibType='SKY')
 


### PR DESCRIPTION
This PR replaces all requests for the `Exposure.filterLabel` Middleware component with `Exposure.filter`.