### PR TITLE
DM-36280: Fix incorrect dataset type for CTI dataset in IsrTask

### DIFF
--- a/python/lsst/cp/pipe/deferredCharge.py
+++ b/python/lsst/cp/pipe/deferredCharge.py
@@ -65,6 +65,7 @@ class CpCtiSolveConnections(pipeBase.PipelineTaskConnections,
         doc="Output CTI calibration.",
         storageClass="IsrCalib",
         dimensions=("instrument", "detector"),
+        isCalibration=True,
     )
 
 


### PR DESCRIPTION
Fix CTI output connection, making it a calibration.