### PR TITLE
DM-36885: Ensure cp_pipe only uses a different ISR output when needed

### DIFF
--- a/pipelines/Latiss/cpSky.yaml
+++ b/pipelines/Latiss/cpSky.yaml
@@ -6,7 +6,6 @@ tasks:
   isr:
     class: lsst.ip.isr.isrTask.IsrTask
     config:
-      connections.outputExposure: cpSkyIsr
       overscan.fitType: 'MEDIAN_PER_ROW'
       doLinearize: false
       doCrosstalk: true

--- a/pipelines/cpSky.yaml
+++ b/pipelines/cpSky.yaml
@@ -2,10 +2,10 @@ description: Sky frame generation pipeline definition.
 tasks:
   isr:
     class: lsst.ip.isr.isrTask.IsrTask
-    config:
-      connections.outputExposure: cpSkyIsr
   cpSkyImage:
     class: lsst.cp.pipe.CpSkyImageTask
+    config:
+      connections.inputExp: postISRCCD
   cpSkyScaleMeasure:
     class: lsst.cp.pipe.CpSkyScaleMeasureTask
   cpSkySubtractBackground:

--- a/python/lsst/cp/pipe/cpSkyTask.py
+++ b/python/lsst/cp/pipe/cpSkyTask.py
@@ -39,7 +39,7 @@ __all__ = ['CpSkyImageTask', 'CpSkyImageConfig',
 class CpSkyImageConnections(pipeBase.PipelineTaskConnections,
                             dimensions=("instrument", "physical_filter", "exposure", "detector")):
     inputExp = cT.Input(
-        name="cpSkyIsr",
+        name="postISRCCD",
         doc="Input pre-processed exposures to combine.",
         storageClass="Exposure",
         dimensions=("instrument", "exposure", "detector"),


### PR DESCRIPTION
Switch cpSky to operate on postISRCCD datasetType.