### PR TITLE
DM-37643: ci_cpp_gen3 fails on cpPtcExtract when noise is None

### DIFF
--- a/python/lsst/cp/pipe/ptc/cpExtractPtcTask.py
+++ b/python/lsst/cp/pipe/ptc/cpExtractPtcTask.py
@@ -756,9 +756,9 @@ class PhotonTransferCurveExtractTask(pipeBase.PipelineTask):
         if correctionType not in ['NONE', 'SIMPLE', 'FULL']:
             raise RuntimeError("Unknown correction type: %s" % correctionType)
 
-        if correctionType != 'NONE' and readNoise is None:
+        if correctionType != 'NONE' and not np.isfinite(readNoise):
             self.log.warning("'correctionType' in 'getGainFromFlatPair' is %s, "
-                             "but 'readNoise' is 'None'. Setting 'correctionType' "
+                             "but 'readNoise' is NaN. Setting 'correctionType' "
                              "to 'NONE', so a gain value will be estimated without "
                              "corrections." % correctionType)
             correctionType = 'NONE'
@@ -824,6 +824,6 @@ class PhotonTransferCurveExtractTask(pipeBase.PipelineTask):
         else:
             self.log.warning("Median readout noise from ISR metadata for amp %s "
                              "could not be calculated." % ampName)
-            readNoise = None
+            readNoise = np.nan
 
         return readNoise


### PR DESCRIPTION
Use NaN instead of None to prevent potential serialization issues.