### PR TITLE
DM-38163: Update PTC to avoid potential failures

### DIFF
--- a/python/lsst/cp/pipe/ptc/cpExtractPtcTask.py
+++ b/python/lsst/cp/pipe/ptc/cpExtractPtcTask.py
@@ -349,7 +349,8 @@ class PhotonTransferCurveExtractTask(pipeBase.PipelineTask):
         # dimensions match.
         dummyPtcDataset = PhotonTransferCurveDataset(ampNames, 'DUMMY',
                                                      self.config.maximumRangeCovariancesAstier)
-
+        for ampName in ampNames:
+            dummyPtcDataset.setAmpValues(ampName)
         # Get read noise.  Try from the exposure, then try
         # taskMetadata.  This adds a get() for the exposures.
         readNoiseLists = {}

--- a/python/lsst/cp/pipe/ptc/cpSolvePtcTask.py
+++ b/python/lsst/cp/pipe/ptc/cpSolvePtcTask.py
@@ -219,8 +219,14 @@ class PhotonTransferCurveSolveTask(pipeBase.PipelineTask):
                 means, variances, and exposure times
                 (`lsst.ip.isr.PhotonTransferCurveDataset`).
         """
+        # Find the ampNames from a non-dummy ptc.
+        ampNames = []
+        for partialPtcDataset in inputCovariances:
+            if partialPtcDataset.ptcFitType != 'DUMMY':
+                ampNames = partialPtcDataset.ampNames
+                break
+
         # Assemble individual PTC datasets into a single PTC dataset.
-        ampNames = np.unique(inputCovariances[0].ampNames)
         datasetPtc = PhotonTransferCurveDataset(ampNames=ampNames,
                                                 ptcFitType=self.config.ptcFitType,
                                                 covMatrixSide=self.config.maximumRangeCovariancesAstier)

--- a/tests/test_ptc.py
+++ b/tests/test_ptc.py
@@ -55,6 +55,8 @@ class PretendRef():
             return self.exp.getVisitInfo()
         elif component == 'detector':
             return self.exp.getDetector()
+        elif component == 'metadata':
+            return self.exp.getMetadata()
         else:
             return self.exp
 

--- a/tests/test_ptc.py
+++ b/tests/test_ptc.py
@@ -166,7 +166,7 @@ class MeasurePhotonTransferCurveTaskTestCase(lsst.utils.tests.TestCase):
             idCounter += 2
 
         resultsExtract = extractTask.run(inputExp=expDict, inputDims=expIds,
-                                         taskMetadata=[self.metadataContents])
+                                         taskMetadata=[self.metadataContents for x in expIds])
 
         # Force the last PTC dataset to have a NaN, and ensure that the
         # task runs (DM-38029).  This is a minor perturbation and does not
@@ -465,7 +465,7 @@ class MeasurePhotonTransferCurveTaskTestCase(lsst.utils.tests.TestCase):
             idCounter += 2
 
         resultsExtract = extractTask.run(inputExp=expDict, inputDims=expIds,
-                                         taskMetadata=[self.metadataContents])
+                                         taskMetadata=[self.metadataContents for x in expIds])
         for exposurePair in resultsExtract.outputCovariances:
             for ampName in self.ampNames:
                 if exposurePair.gain[ampName] is np.nan:


### PR DESCRIPTION
PTC improvements:

- Ensure all outputRefs have a matching outputCovariance (this is a problem blocking DM-37383).
- Try to get read noise from the exposure header.
- Get ampNames for the solve task from a non-dummy input, and anticipate associated bug fix on the PTC dataset in `ip_isr`.
- Update tests to pass full set of taskMetadata to mimic real butler behavior.