### PR TITLE
DM-38944: Move photodiode computations from linearity to ptc code.

### DIFF
--- a/pipelines/Latiss/cpLinearitySolve.yaml
+++ b/pipelines/Latiss/cpLinearitySolve.yaml
@@ -3,7 +3,7 @@ instrument: lsst.obs.lsst.Latiss
 imports:
   - location: $CP_PIPE_DIR/pipelines/_ingredients/cpLinearitySolve.yaml
 tasks:
-  linearitySolve:
+  linearitySolveBase:
     class: lsst.cp.pipe.LinearitySolveTask
     config:
       linearityType: Spline

--- a/pipelines/LsstCam/cpLinearitySolve.yaml
+++ b/pipelines/LsstCam/cpLinearitySolve.yaml
@@ -3,9 +3,10 @@ instrument: lsst.obs.lsst.LsstCam
 imports:
   - location: $CP_PIPE_DIR/pipelines/_ingredients/cpLinearitySolve.yaml
 tasks:
-  linearitySolve:
+  linearitySolveBase:
     class: lsst.cp.pipe.LinearitySolveTask
     config:
       linearityType: Spline
       usePhotodiode: true
       splineGroupingColumn: CCOBCURR
+      maxLinearAdu: 120000

--- a/pipelines/LsstCam/cpLinearitySolve.yaml
+++ b/pipelines/LsstCam/cpLinearitySolve.yaml
@@ -2,3 +2,10 @@ description: cp_pipe linearity calibration construction.
 instrument: lsst.obs.lsst.LsstCam
 imports:
   - location: $CP_PIPE_DIR/pipelines/_ingredients/cpLinearitySolve.yaml
+tasks:
+  linearitySolve:
+    class: lsst.cp.pipe.LinearitySolveTask
+    config:
+      linearityType: Spline
+      usePhotodiode: true
+      splineGroupingColumn: CCOBCURR

--- a/pipelines/LsstCam/cpPtc.yaml
+++ b/pipelines/LsstCam/cpPtc.yaml
@@ -12,3 +12,6 @@ tasks:
     config:
       edgeMaskLevel: AMP
       numEdgeSuspect: 20
+      doExtractPhotodiodeData: true
+      auxiliaryHeaderKeys: ["CCOBCURR", "CCOBFLUX"]
+      matchExposuresType: FLUX

--- a/pipelines/LsstCam/cpPtcNoPhotodiode.yaml
+++ b/pipelines/LsstCam/cpPtcNoPhotodiode.yaml
@@ -1,0 +1,9 @@
+description: LSSTCam Photon-Transfer Curve calibration construction (no photodiode data).
+instrument: lsst.obs.lsst.LsstCam
+imports:
+  - location: $CP_PIPE_DIR/pipelines/LSSTCam/cpPtc.yaml
+tasks:
+  ptcExtract:
+    class: lsst.cp.pipe.ptc.PhotonTransferCurveExtractTask
+    config:
+      doExtractPhotodiodeData: false

--- a/pipelines/LsstTS8/cpLinearitySolve.yaml
+++ b/pipelines/LsstTS8/cpLinearitySolve.yaml
@@ -2,3 +2,11 @@ description: cp_pipe linearity calibration construction.
 instrument: lsst.obs.lsst.LsstTS8
 imports:
   - location: $CP_PIPE_DIR/pipelines/_ingredients/cpLinearitySolve.yaml
+tasks:
+  linearitySolveBase:
+    class: lsst.cp.pipe.LinearitySolveTask
+    config:
+      linearityType: Spline
+      usePhotodiode: true
+      splineGroupingColumn: CCOBCURR
+      maxLinearAdu: 120000

--- a/pipelines/LsstTS8/cpPtc.yaml
+++ b/pipelines/LsstTS8/cpPtc.yaml
@@ -12,3 +12,6 @@ tasks:
     config:
       edgeMaskLevel: AMP
       numEdgeSuspect: 20
+      doExtractPhotodiodeData: true
+      auxiliaryHeaderKeys: ["CCOBCURR", "CCOBFLUX"]
+      matchExposuresType: FLUX

--- a/pipelines/_ingredients/cpLinearitySolve.yaml
+++ b/pipelines/_ingredients/cpLinearitySolve.yaml
@@ -1,6 +1,6 @@
 description: cp_pipe linearity calibration construction.
 tasks:
-  linearitySolve:
+  linearitySolveBase:
     class: lsst.cp.pipe.LinearitySolveTask
     config:
       connections.inputPtc: ptc

--- a/python/lsst/cp/pipe/linearity.py
+++ b/python/lsst/cp/pipe/linearity.py
@@ -464,7 +464,7 @@ class LinearitySolveTask(pipeBase.PipelineTask):
                 # fits deviations from linearity, rather than the linear
                 # function itself which is degenerate with the gain.
 
-                nodes = np.linspace(0.0, inputOrdinate.max(), self.config.splineKnots)
+                nodes = np.linspace(0.0, np.max(inputOrdinate[mask]), self.config.splineKnots)
 
                 fitter = AstierSplineLinearityFitter(
                     nodes,

--- a/python/lsst/cp/pipe/ptc/cpSolvePtcTask.py
+++ b/python/lsst/cp/pipe/ptc/cpSolvePtcTask.py
@@ -296,6 +296,8 @@ class PhotonTransferCurveSolveTask(pipeBase.PipelineTask):
                                                          partialPtcDataset.rawMeans[ampName][0])
                 datasetPtc.rawVars[ampName] = np.append(datasetPtc.rawVars[ampName],
                                                         partialPtcDataset.rawVars[ampName][0])
+                datasetPtc.photoCharges[ampName] = np.append(datasetPtc.photoCharges[ampName],
+                                                             partialPtcDataset.photoCharges[ampName][0])
                 datasetPtc.histVars[ampName] = np.append(datasetPtc.histVars[ampName],
                                                          partialPtcDataset.histVars[ampName][0])
                 datasetPtc.histChi2Dofs[ampName] = np.append(datasetPtc.histChi2Dofs[ampName],
@@ -367,6 +369,7 @@ class PhotonTransferCurveSolveTask(pipeBase.PipelineTask):
             datasetPtc.rawExpTimes[ampName] = datasetPtc.rawExpTimes[ampName][index]
             datasetPtc.rawMeans[ampName] = datasetPtc.rawMeans[ampName][index]
             datasetPtc.rawVars[ampName] = datasetPtc.rawVars[ampName][index]
+            datasetPtc.photoCharges[ampName] = datasetPtc.photoCharges[ampName][index]
             datasetPtc.histVars[ampName] = datasetPtc.histVars[ampName][index]
             datasetPtc.histChi2Dofs[ampName] = datasetPtc.histChi2Dofs[ampName][index]
             datasetPtc.kspValues[ampName] = datasetPtc.kspValues[ampName][index]

--- a/python/lsst/cp/pipe/utils.py
+++ b/python/lsst/cp/pipe/utils.py
@@ -855,7 +855,7 @@ class AstierSplineLinearityFitter:
         p0 = np.zeros(npt)
 
         # Do a simple linear fit and set all the constants to this.
-        linfit = np.polyfit(self._pd, self._mu, 1)
+        linfit = np.polyfit(self._pd[self.mask], self._mu[self.mask], 1)
         p0[-self.ngroup:] = linfit[0]
 
         # Look at the residuals...
@@ -867,7 +867,7 @@ class AstierSplineLinearityFitter:
             self._mu,
         )
         # ...and adjust the linear parameters accordingly.
-        p0[-self.ngroup:] *= np.median(ratio_model)
+        p0[-self.ngroup:] *= np.median(ratio_model[self.mask])
 
         # Re-compute the residuals.
         ratio_model2 = self.compute_ratio_model(
@@ -879,10 +879,10 @@ class AstierSplineLinearityFitter:
         )
 
         # And compute a first guess of the spline nodes.
-        bins = np.searchsorted(self._nodes, self._mu)
+        bins = np.searchsorted(self._nodes, self._mu[self.mask])
         tot_arr = np.zeros(len(self._nodes))
         n_arr = np.zeros(len(self._nodes), dtype=int)
-        np.add.at(tot_arr, bins, ratio_model2)
+        np.add.at(tot_arr, bins, ratio_model2[self.mask])
         np.add.at(n_arr, bins, 1)
 
         ratio = np.ones(len(self._nodes))
@@ -1014,6 +1014,8 @@ class AstierSplineLinearityFitter:
         )
 
         resid = self._w*(ratio_model - 1.0)
+        # Ensure masked points have 0 residual.
+        resid[~self.mask] = 0.0
 
         constraint = [1e3 * np.mean(spl.interpolate(self._x_regularize))]
         # 0 should transform to 0

--- a/tests/test_linearity.py
+++ b/tests/test_linearity.py
@@ -285,6 +285,12 @@ class LinearityTaskTestCase(lsst.utils.tests.TestCase):
             pd_values_offset[group2] *= pd_offset_factors[2]
             pd_values_offset[group3] *= pd_offset_factors[3]
 
+        # Add one bad photodiode value, but don't put it at the very
+        # end because that would change the spline node positions
+        # and make comparisons to the "truth" here in the tests
+        # more difficult.
+        pd_values_offset[-2] = np.nan
+
         ptc = self._create_ptc(
             self.amp_names,
             time_values,

--- a/tests/test_linearity.py
+++ b/tests/test_linearity.py
@@ -30,7 +30,7 @@ import numpy as np
 import lsst.utils
 import lsst.utils.tests
 
-from lsst.ip.isr import PhotonTransferCurveDataset, PhotodiodeCalib
+from lsst.ip.isr import PhotonTransferCurveDataset
 
 import lsst.afw.image
 import lsst.afw.math
@@ -63,7 +63,7 @@ class LinearityTaskTestCase(lsst.utils.tests.TestCase):
         for amp in self.detector:
             self.amp_names.append(amp.getName())
 
-    def _create_ptc(self, amp_names, exp_times, means, ccobcurr=None):
+    def _create_ptc(self, amp_names, exp_times, means, ccobcurr=None, photo_charges=None):
         """
         Create a PTC with values for linearity tests.
 
@@ -77,6 +77,8 @@ class LinearityTaskTestCase(lsst.utils.tests.TestCase):
             Array of means.
         ccobcurr : `np.ndarray`, optional
             Array of CCOBCURR to put into auxiliary values.
+        photo_charges : `np.ndarray`, optional
+            Array of photoCharges to put into ptc.
 
         Returns
         -------
@@ -84,6 +86,9 @@ class LinearityTaskTestCase(lsst.utils.tests.TestCase):
             PTC filled with relevant values.
         """
         exp_id_pairs = np.arange(len(exp_times)*2).reshape((len(exp_times), 2)).tolist()
+
+        if photo_charges is None:
+            photo_charges = np.full(len(exp_times), np.nan)
 
         datasets = []
         for i in range(len(exp_times)):
@@ -103,6 +108,7 @@ class LinearityTaskTestCase(lsst.utils.tests.TestCase):
                     rawVar=1.0,
                     kspValue=1.0,
                     expIdMask=exp_id_mask,
+                    photoCharge=photo_charges[i],
                 )
 
             if ccobcurr is not None:
@@ -279,40 +285,17 @@ class LinearityTaskTestCase(lsst.utils.tests.TestCase):
             pd_values_offset[group2] *= pd_offset_factors[2]
             pd_values_offset[group3] *= pd_offset_factors[3]
 
-        ptc = self._create_ptc(self.amp_names, time_values, mu_values, ccobcurr=ccobcurr)
-
-        # And create a bunch of PD datasets.
-        amp_name = ptc.ampNames[0]
-        exp_id_pairs = ptc.inputExpIdPairs[amp_name]
-
-        pd_handles = []
-
-        for i, exp_id_pair in enumerate(exp_id_pairs):
-            time_samples = np.linspace(0, 20.0, 100)
-            current_samples = np.zeros(100)
-            current_samples[50] = -1.0*pd_values_offset[i]
-
-            pd_calib = PhotodiodeCalib(timeSamples=time_samples, currentSamples=current_samples)
-            pd_calib.currentScale = -1.0
-            pd_calib.integrationMethod = "CHARGE_SUM"
-
-            pd_handles.append(
-                lsst.pipe.base.InMemoryDatasetHandle(
-                    pd_calib,
-                    dataId={"exposure": exp_id_pair[0]},
-                )
-            )
-            pd_handles.append(
-                lsst.pipe.base.InMemoryDatasetHandle(
-                    pd_calib,
-                    dataId={"exposure": exp_id_pair[1]},
-                )
-            )
+        ptc = self._create_ptc(
+            self.amp_names,
+            time_values,
+            mu_values,
+            ccobcurr=ccobcurr,
+            photo_charges=pd_values_offset,
+        )
 
         config = LinearitySolveTask.ConfigClass()
         config.linearityType = "Spline"
         config.usePhotodiode = True
-        config.photodiodeIntegrationMethod = "CHARGE_SUM"
         config.minLinearAdu = 0.0
         config.maxLinearAdu = np.max(mu_values) + 1.0
         config.splineKnots = n_nodes
@@ -326,7 +309,6 @@ class LinearityTaskTestCase(lsst.utils.tests.TestCase):
             [self.dummy_exposure],
             self.camera,
             self.input_dims,
-            inputPhotodiodeData=pd_handles,
         ).outputLinearizer
 
         # Skip the last amp which is marked bad.

--- a/tests/test_linearity.py
+++ b/tests/test_linearity.py
@@ -334,7 +334,7 @@ class LinearityTaskTestCase(lsst.utils.tests.TestCase):
             self.assertFloatsAlmostEqual(
                 (linearizer.fitResiduals[amp_name][lin_mask] / mu_linear[lin_mask])[1:],
                 0.0,
-                atol=1e-3,
+                atol=1.1e-3,
             )
 
             # If we apply the linearity correction, we should get the true
@@ -368,8 +368,8 @@ class LinearityTaskTestCase(lsst.utils.tests.TestCase):
             # approximate, and the real test is in the residuals.
             small = (np.abs(non_lin_spline_values) < 20)
 
-            spline_atol = 5.0 if do_pd_offsets else 2.0
-            spline_rtol = 0.1 if do_pd_offsets else 0.05
+            spline_atol = 6.0 if do_pd_offsets else 2.0
+            spline_rtol = 0.14 if do_pd_offsets else 0.05
 
             self.assertFloatsAlmostEqual(
                 linearizer.linearityCoeffs[amp_name][n_nodes:][small],


### PR DESCRIPTION
This moves the photodiode connections and integration code from the linearity code to the PTC code.  This will use the photoCharges part of the PTC dataset which was previously unfilled.

This also updates the default PTC and linearity pipelines for LSSTCam as appropriate.