### PR TITLE
DM-33862: Very high flux flats trigger tons of CR detections

### DIFF
--- a/python/lsst/cp/pipe/utils.py
+++ b/python/lsst/cp/pipe/utils.py
@@ -22,17 +22,18 @@
 
 __all__ = ['ddict2dict', 'CovFastFourierTransform']
 
-import numpy as np
-from scipy.optimize import leastsq
-import numpy.polynomial.polynomial as poly
-from scipy.stats import median_abs_deviation, norm
+
+import galsim
 import logging
+import numpy as np
+import numpy.polynomial.polynomial as poly
+
+from scipy.optimize import leastsq
+from scipy.stats import median_abs_deviation, norm
 
 from lsst.ip.isr import isrMock
 import lsst.afw.image
 import lsst.afw.math
-
-import galsim
 
 
 def sigmaClipCorrection(nSigClip):


### PR DESCRIPTION
This PR removes the old ad-hoc exposure time scaling, and replaces it with a scaling of the variance plane solely for the CR detection.  This resolves the signal-to-noise issue that was allowing a large fraction of pixels to pass the "condition 3" test.