### PR TITLE
DM-42024: Allow for low gains and allow initial outlier cutoff to have units of electrons.

### DIFF
--- a/python/lsst/cp/pipe/ptc/cpSolvePtcTask.py
+++ b/python/lsst/cp/pipe/ptc/cpSolvePtcTask.py
@@ -1005,8 +1005,8 @@ class PhotonTransferCurveSolveTask(pipeBase.PipelineTask):
                 if self.config.binSize > 1:
                     bounds = self._boundsForAstier(parsIniPtc)
                 else:
-                    bounds = self._boundsForAstier(parsIniPtc, lowers=[-1e-4, 0.5, -2000],
-                                                   uppers=[1e-4, 2.5, 2000])
+                    bounds = self._boundsForAstier(parsIniPtc, lowers=[-1e-4, 0.1, -2000],
+                                                   uppers=[1e-4, 10.0, 2000])
             if ptcFitType == 'POLYNOMIAL':
                 ptcFunc = funcPolynomial
                 parsIniPtc = self._initialParsForPolynomial(self.config.polynomialFitDegree + 1)

--- a/tests/test_linearity.py
+++ b/tests/test_linearity.py
@@ -107,7 +107,7 @@ class LinearityTaskTestCase(lsst.utils.tests.TestCase):
                     inputExpIdPair=exp_id_pairs[i],
                     rawExpTime=exp_times[i],
                     rawMean=raw_mean,
-                    rawVar=1.0,
+                    rawVar=raw_mean,
                     kspValue=1.0,
                     expIdMask=exp_id_mask,
                     photoCharge=photo_charges[i],


### PR DESCRIPTION
This fixes a bug where low gains (<0.5) were not allowed in the fit.  It also now changes `maxADUInitialPtcOutlierFit` to default of units of electrons that can then be scaled by an initial estimate of the gain.  This allows the cutoff to be approximately invariant across a range of gain settings.