### PR TITLE
DM-42643:  Pre-process data into catalog format for analysis_tools

### DIFF
--- a/python/lsst/cp/pipe/cpCombine.py
+++ b/python/lsst/cp/pipe/cpCombine.py
@@ -635,8 +635,8 @@ class CalibCombineTask(pipeBase.PipelineTask):
         # percentiles
         for amp in exp.getDetector():
             ampImage = exp[amp.getBBox()]
-            percentileValues = np.percentile(ampImage.image.array,
-                                             self.config.distributionPercentiles)
+            percentileValues = np.nanpercentile(ampImage.image.array,
+                                                self.config.distributionPercentiles)
             for level, value in zip(self.config.distributionPercentiles, percentileValues):
                 key = f"LSST CALIB {calibrationType.upper()} {amp.getName()} DISTRIBUTION {level}-PCT"
                 metadata[key] = value


### PR DESCRIPTION
Prevent nan values.

Jenkins returns nan values that do not appear when manually running.  