### PR TITLE
DM-33453: Update pipeline references in response to RFC-775.

### DIFF
--- a/pipelines/DarkEnergyCamera/RunIsrForCrosstalkSources.yaml
+++ b/pipelines/DarkEnergyCamera/RunIsrForCrosstalkSources.yaml
@@ -1,4 +1,4 @@
 description: Prepare crosstalkSources for ISR/interchip crosstalk by running overscan correction on raw frames.
 instrument: lsst.obs.decam.DarkEnergyCamera
 imports:
-  - location: $AP_PIPE_DIR/pipelines/DarkEnergyCamera/RunIsrForCrosstalkSources.yaml
+  - location: $AP_PIPE_DIR/pipelines/DECam/RunIsrForCrosstalkSources.yaml


### PR DESCRIPTION
Changed `DarkEnergyCamera` to `DECam` in response to RFC-775.