### PR TITLE
DM-43377: Add more features to defect finding code and update LATISS pipeline.

### DIFF
--- a/pipelines/Latiss/findDefectsCombined.yaml
+++ b/pipelines/Latiss/findDefectsCombined.yaml
@@ -7,6 +7,7 @@ tasks:
     class: lsst.cp.pipe.defects.MeasureDefectsCombinedTask
     config:
       badPixelsToFillColumnThreshold: 1000
+      saturatedPixelsToFillColumnThreshold: 20
       saturatedColumnDilationRadius: 3
   measureDefectsDark:
     class: lsst.cp.pipe.defects.MeasureDefectsCombinedTask
@@ -14,6 +15,7 @@ tasks:
       thresholdType: "VALUE"
       darkCurrentThreshold: 3.0
       badPixelsToFillColumnThreshold: 1000
+      saturatedPixelsToFillColumnThreshold: 20
       saturatedColumnDilationRadius: 3
   measureDefectsFlatx:
     class: lsst.cp.pipe.defects.MeasureDefectsCombinedWithFilterTask

--- a/pipelines/Latiss/findDefectsCombined.yaml
+++ b/pipelines/Latiss/findDefectsCombined.yaml
@@ -7,12 +7,14 @@ tasks:
     class: lsst.cp.pipe.defects.MeasureDefectsCombinedTask
     config:
       badPixelsToFillColumnThreshold: 1000
+      saturatedColumnDilationRadius: 3
   measureDefectsDark:
     class: lsst.cp.pipe.defects.MeasureDefectsCombinedTask
     config:
       thresholdType: "VALUE"
       darkCurrentThreshold: 3.0
       badPixelsToFillColumnThreshold: 1000
+      saturatedColumnDilationRadius: 3
   measureDefectsFlatx:
     class: lsst.cp.pipe.defects.MeasureDefectsCombinedWithFilterTask
     config:

--- a/pipelines/Latiss/findDefectsCombined.yaml
+++ b/pipelines/Latiss/findDefectsCombined.yaml
@@ -8,7 +8,7 @@ tasks:
     config:
       badPixelsToFillColumnThreshold: 1000
       saturatedPixelsToFillColumnThreshold: 20
-      saturatedColumnDilationRadius: 3
+      saturatedColumnDilationRadius: 2
   measureDefectsDark:
     class: lsst.cp.pipe.defects.MeasureDefectsCombinedTask
     config:
@@ -16,7 +16,7 @@ tasks:
       darkCurrentThreshold: 3.0
       badPixelsToFillColumnThreshold: 1000
       saturatedPixelsToFillColumnThreshold: 20
-      saturatedColumnDilationRadius: 3
+      saturatedColumnDilationRadius: 2
   measureDefectsFlatx:
     class: lsst.cp.pipe.defects.MeasureDefectsCombinedWithFilterTask
     config:

--- a/pipelines/Latiss/findDefectsCombined.yaml
+++ b/pipelines/Latiss/findDefectsCombined.yaml
@@ -3,16 +3,22 @@ instrument: lsst.obs.lsst.Latiss
 imports:
   - location: $CP_PIPE_DIR/pipelines/_ingredients/findDefectsCombined.yaml
 tasks:
+  measureDefectsBias:
+    class: lsst.cp.pipe.defects.MeasureDefectsCombinedTask
+    config:
+      badPixelsToFillColumnThreshold: 1000
   measureDefectsDark:
     class: lsst.cp.pipe.defects.MeasureDefectsCombinedTask
     config:
       thresholdType: "VALUE"
       darkCurrentThreshold: 3.0
+      badPixelsToFillColumnThreshold: 1000
   measureDefectsFlatx:
     class: lsst.cp.pipe.defects.MeasureDefectsCombinedWithFilterTask
     config:
       thresholdType: "VALUE"
       fracThresholdFlat: 0.9
+      badPixelsToFillColumnThreshold: 1000
   mergeDefectsCombined:
     class: lsst.cp.pipe.defects.MergeDefectsCombinedTask
     config:

--- a/pipelines/_ingredients/cpBias.yaml
+++ b/pipelines/_ingredients/cpBias.yaml
@@ -30,6 +30,7 @@ tasks:
       connections.outputData: 'bias'
       calibrationType: 'bias'
       exposureScaling: "Unity"
+      mask: ["DETECTED", "INTRP"]
 contracts:
   - biasIsr.doBias == False
   - cpBiasCombine.calibrationType == "bias"

--- a/pipelines/_ingredients/cpBias.yaml
+++ b/pipelines/_ingredients/cpBias.yaml
@@ -16,7 +16,10 @@ tasks:
       doFlat: false
       doApplyGains: false
       doFringe: false
-      doSaturation: false
+      doSaturation: true
+      growSaturationFootprintSize: 0
+      doWidenSaturationTrails: false
+      doSaturationInterpolation: false
       maskNegativeVariance: false
       doInterpolate: false
       doSetBadRegions: false

--- a/pipelines/_ingredients/cpDarkForDefects.yaml
+++ b/pipelines/_ingredients/cpDarkForDefects.yaml
@@ -15,7 +15,10 @@ tasks:
       doFlat: false
       doApplyGains: false
       doFringe: false
-      doSaturation: false
+      doSaturation: true
+      growSaturationFootprintSize: 0
+      doWidenSaturationTrails: false
+      doSaturationInterpolation: false
       maskNegativeVariance: false
       doInterpolate: false
       doSetBadRegions: false

--- a/pipelines/_ingredients/cpDarkForDefects.yaml
+++ b/pipelines/_ingredients/cpDarkForDefects.yaml
@@ -29,6 +29,7 @@ tasks:
       connections.outputData: 'dark'
       calibrationType: 'dark'
       exposureScaling: "DarkTime"
+      mask: ["DETECTED", "INTRP"]
 contracts:
   - darkIsrForDefects.doDark == False
   - cpDarkCombine.calibrationType == "dark"


### PR DESCRIPTION
This also changes the general defect pipeline to mark saturated pixels but not count them as bad/interpolate/anything so that the defect finding code can know which pixels were saturated.