### PR TITLE
DM-44259-hotfix-docs: Remove extraneous paths from task names in docs.

### DIFF
--- a/doc/lsst.cp.pipe/index.rst
+++ b/doc/lsst.cp.pipe/index.rst
@@ -49,16 +49,6 @@ Tasks
    :root: lsst.cp.pipe
    :toctree: tasks
 
-.. _lsst.cp.pipe-scripts:
-
-Script reference
-================
-
-.. toctree::
-   :maxdepth: 1
-
-   scripts/plotPhotonTransferCurve.py
-
 .. _lsst.cp.pipe-pyapi:
 
 Python API reference
@@ -68,15 +58,15 @@ Python API reference
    :no-main-docstr:
    :no-inheritance-diagram:
 
-.. automodapi:: lsst.cp.pipe.cpFlatNormTask
+.. automodapi:: lsst.cp.pipe.cpFlatMeasure
    :no-main-docstr:
    :no-inheritance-diagram:
 
-.. automodapi:: lsst.cp.pipe.cpDarkTask
+.. automodapi:: lsst.cp.pipe.cpDark
    :no-main-docstr:
    :no-inheritance-diagram:
 
-.. automodapi:: lsst.cp.pipe.cpFringeTask
+.. automodapi:: lsst.cp.pipe.cpFringe
    :no-main-docstr:
    :no-inheritance-diagram:
 

--- a/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpDarkTask.rst
+++ b/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpDarkTask.rst
@@ -1,4 +1,4 @@
-.. lsst-task-topic:: lsst.cp.pipe.cpDarkTask.CpDarkTask
+.. lsst-task-topic:: lsst.cp.pipe.CpDarkTask
 
 ##########
 CpDarkTask
@@ -6,7 +6,7 @@ CpDarkTask
 
 ``CpDarkTask`` preprocesses exposures after :lsst-task:`~lsst.ip.isr.IsrTask` and before the final dark combination.
 
-.. _lsst.cp.pipe.cpDarkTask.CpDarkTask-processing-summary:
+.. _lsst.cp.pipe.CpDarkTask-processing-summary:
 
 Processing summary
 ==================
@@ -16,23 +16,23 @@ Processing summary
 #. Identifies and masks cosmic rays.
 #. Optionally grows the cosmic ray masks to ensure they do not bleed through into the final combination.
 
-.. _lsst.cp.pipe.cpDarkTask.CpDarkTask-api:
+.. _lsst.cp.pipe.CpDarkTask-api:
 
 Python API summary
 ==================
 
-.. lsst-task-api-summary:: lsst.cp.pipe.cpDarkTask.CpDarkTask
+.. lsst-task-api-summary:: lsst.cp.pipe.CpDarkTask
 
-.. _lsst.cp.pipe.cpDarkTask.CpDarkTask-subtasks:
+.. _lsst.cp.pipe.CpDarkTask-subtasks:
 
 Retargetable subtasks
 =====================
 
-.. lsst-task-config-subtasks:: lsst.cp.pipe.cpDarkTask.CpDarkTask
+.. lsst-task-config-subtasks:: lsst.cp.pipe.CpDarkTask
 
-.. _lsst.cp.pipe.cpDarkTask.CpDarkTask-configs:
+.. _lsst.cp.pipe.CpDarkTask-configs:
 
 Configuration fields
 ====================
 
-.. lsst-task-config-fields:: lsst.cp.pipe.cpDarkTask.CpDarkTask
+.. lsst-task-config-fields:: lsst.cp.pipe.CpDarkTask

--- a/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpFlatMeasureTask.rst
+++ b/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpFlatMeasureTask.rst
@@ -1,12 +1,12 @@
-.. lsst-task-topic:: lsst.cp.pipe.cpFlatNormTask.CpFlatMeasureTask
+.. lsst-task-topic:: lsst.cp.pipe.CpFlatMeasureTask
 
 #################
 CpFlatMeasureTask
 #################
 
-``CpFlatMeasureTask`` measures image statistics from the input flat field frames to supply the information needed for :lsst-task:`~lsst.cp.pipe.cpFlatNormTask.CpFlatNormalizationTask` to determine approprate scale factors.
+``CpFlatMeasureTask`` measures image statistics from the input flat field frames to supply the information needed for :lsst-task:`~lsst.cp.pipe.CpFlatNormalizationTask` to determine approprate scale factors.
 
-.. _lsst.cp.pipe.cpFlatNormTask.CpFlatMeasureTask-processing-summary:
+.. _lsst.cp.pipe.CpFlatMeasureTask-processing-summary:
 
 Processing summary
 ==================
@@ -17,23 +17,23 @@ Processing summary
 #. Measures detector level clipped mean, clipped sigma, and number of pixels.
 #. Measures the same statistics at the amplifier level.
 
-.. _lsst.cp.pipe.cpFlatNormTask.CpFlatMeasureTask-api:
+.. _lsst.cp.pipe.CpFlatMeasureTask-api:
 
 Python API summary
 ==================
 
-.. lsst-task-api-summary:: lsst.cp.pipe.cpFlatNormTask.CpFlatMeasureTask
+.. lsst-task-api-summary:: lsst.cp.pipe.CpFlatMeasureTask
 
-.. _lsst.cp.pipe.cpFlatNormTask.CpFlatMeasureTask-subtasks:
+.. _lsst.cp.pipe.CpFlatMeasureTask-subtasks:
 
 Retargetable subtasks
 =====================
 
-.. lsst-task-config-subtasks:: lsst.cp.pipe.cpFlatNormTask.CpFlatMeasureTask
+.. lsst-task-config-subtasks:: lsst.cp.pipe.CpFlatMeasureTask
 
-.. _lsst.cp.pipe.cpFlatNormTask.CpFlatMeasureTask-configs:
+.. _lsst.cp.pipe.CpFlatMeasureTask-configs:
 
 Configuration fields
 ====================
 
-.. lsst-task-config-fields:: lsst.cp.pipe.cpFlatNormTask.CpFlatMeasureTask
+.. lsst-task-config-fields:: lsst.cp.pipe.CpFlatMeasureTask

--- a/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpFlatNormalizationTask.rst
+++ b/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpFlatNormalizationTask.rst
@@ -1,4 +1,4 @@
-.. lsst-task-topic:: lsst.cp.pipe.cpFlatNormTask.CpFlatNormalizationTask
+.. lsst-task-topic:: lsst.cp.pipe.CpFlatNormalizationTask
 
 #######################
 CpFlatNormalizationTask
@@ -6,7 +6,7 @@ CpFlatNormalizationTask
 
 ``CpFlatNormalizationTask`` determines the scaling factor to apply to each exposure/detector set when constructing the final flat field.
 
-.. _lsst.cp.pipe.cpFlatNormTask.CpFlatNormalizationTask-processing-summary:
+.. _lsst.cp.pipe.CpFlatNormalizationTask-processing-summary:
 
 Processing summary
 ==================
@@ -16,23 +16,23 @@ Processing summary
 #. Combine the set of background measurements for all input exposures for all detectors into a matrix ``B[exposure, detector]``.
 #. Iteratively solve for two vectors ``E[exposure]`` and ``G[detector]`` whose Cartesian product are the best fit to ``B[exposure, detector]``.
 
-.. _lsst.cp.pipe.cpFlatNormTask.CpFlatNormalizationTask-api:
+.. _lsst.cp.pipe.CpFlatNormalizationTask-api:
 
 Python API summary
 ==================
 
-.. lsst-task-api-summary:: lsst.cp.pipe.cpFlatNormTask.CpFlatNormalizationTask
+.. lsst-task-api-summary:: lsst.cp.pipe.CpFlatNormalizationTask
 
-.. _lsst.cp.pipe.cpFlatNormTask.CpFlatNormalizationTask-subtasks:
+.. _lsst.cp.pipe.CpFlatNormalizationTask-subtasks:
 
 Retargetable subtasks
 =====================
 
-.. lsst-task-config-subtasks:: lsst.cp.pipe.cpFlatNormTask.CpFlatNormalizationTask
+.. lsst-task-config-subtasks:: lsst.cp.pipe.CpFlatNormalizationTask
 
-.. _lsst.cp.pipe.cpFlatNormTask.CpFlatNormalizationTask-configs:
+.. _lsst.cp.pipe.CpFlatNormalizationTask-configs:
 
 Configuration fields
 ====================
 
-.. lsst-task-config-fields:: lsst.cp.pipe.cpFlatNormTask.CpFlatNormalizationTask
+.. lsst-task-config-fields:: lsst.cp.pipe.CpFlatNormalizationTask

--- a/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpFringeTask.rst
+++ b/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpFringeTask.rst
@@ -1,4 +1,4 @@
-.. lsst-task-topic:: lsst.cp.pipe.cpFringeTask.CpFringeTask
+.. lsst-task-topic:: lsst.cp.pipe.CpFringeTask
 
 ############
 CpFringeTask
@@ -6,7 +6,7 @@ CpFringeTask
 
 ``CpFringeTask`` preprocesses the input exposures to prepare them for combination into a master fringe calibration.
 
-.. _lsst.cp.pipe.cpFringeTask.CpFringeTask-processing-summary:
+.. _lsst.cp.pipe.CpFringeTask-processing-summary:
 
 Processing summary
 ==================
@@ -16,23 +16,23 @@ Processing summary
 #. Divides the input exposure by the measured background level, normalizing the image sky to 1.0.
 #. Finds all sources above the masking threshold, and masks them
 
-.. _lsst.cp.pipe.cpFringeTask.CpFringeTask-api:
+.. _lsst.cp.pipe.CpFringeTask-api:
 
 Python API summary
 ==================
 
-.. lsst-task-api-summary:: lsst.cp.pipe.cpFringeTask.CpFringeTask
+.. lsst-task-api-summary:: lsst.cp.pipe.CpFringeTask
 
-.. _lsst.cp.pipe.cpFringeTask.CpFringeTask-subtasks:
+.. _lsst.cp.pipe.CpFringeTask-subtasks:
 
 Retargetable subtasks
 =====================
 
-.. lsst-task-config-subtasks:: lsst.cp.pipe.cpFringeTask.CpFringeTask
+.. lsst-task-config-subtasks:: lsst.cp.pipe.CpFringeTask
 
-.. _lsst.cp.pipe.cpFringeTask.CpFringeTask-configs:
+.. _lsst.cp.pipe.CpFringeTask-configs:
 
 Configuration fields
 ====================
 
-.. lsst-task-config-fields:: lsst.cp.pipe.cpFringeTask.CpFringeTask
+.. lsst-task-config-fields:: lsst.cp.pipe.CpFringeTask

--- a/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpSkyCombineTask.rst
+++ b/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpSkyCombineTask.rst
@@ -1,4 +1,4 @@
-.. lsst-task-topic:: lsst.cp.pipe.cpSkyTask.CpSkyCombineTask
+.. lsst-task-topic:: lsst.cp.pipe.CpSkyCombineTask
 
 ################
 CpSkyCombineTask
@@ -6,7 +6,7 @@ CpSkyCombineTask
 
 ``CpSkyCombineTask`` averages the per-exposure background models into a final SKY calibration.
 
-.. _lsst.cp.pipe.cpSkyTask.CpSkyCombineTask-processing-summary:
+.. _lsst.cp.pipe.CpSkyCombineTask-processing-summary:
 
 Processing summary
 ==================
@@ -16,23 +16,23 @@ Processing summary
 #. Average input backgrounds with :lsst-task:`~lsst.pipe.tasks.background.SkyMeasurementTask`.
 #. Combine input headers for the output calibration.
 
-.. _lsst.cp.pipe.cpSkyTask.CpSkyCombineTask-api:
+.. _lsst.cp.pipe.CpSkyCombineTask-api:
 
 Python API summary
 ==================
 
-.. lsst-task-api-summary:: lsst.cp.pipe.cpSkyTask.CpSkyCombineTask
+.. lsst-task-api-summary:: lsst.cp.pipe.CpSkyCombineTask
 
-.. _lsst.cp.pipe.cpSkyTask.CpSkyCombineTask-subtasks:
+.. _lsst.cp.pipe.CpSkyCombineTask-subtasks:
 
 Retargetable subtasks
 =====================
 
-.. lsst-task-config-subtasks:: lsst.cp.pipe.cpSkyTask.CpSkyCombineTask
+.. lsst-task-config-subtasks:: lsst.cp.pipe.CpSkyCombineTask
 
-.. _lsst.cp.pipe.cpSkyTask.CpSkyCombineTask-configs:
+.. _lsst.cp.pipe.CpSkyCombineTask-configs:
 
 Configuration fields
 ====================
 
-.. lsst-task-config-fields:: lsst.cp.pipe.cpSkyTask.CpSkyCombineTask
+.. lsst-task-config-fields:: lsst.cp.pipe.CpSkyCombineTask

--- a/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpSkyImageTask.rst
+++ b/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpSkyImageTask.rst
@@ -1,4 +1,4 @@
-.. lsst-task-topic:: lsst.cp.pipe.cpSkyTask.CpSkyImageTask
+.. lsst-task-topic:: lsst.cp.pipe.CpSkyImageTask
 
 ##############
 CpSkyImageTask
@@ -6,7 +6,7 @@ CpSkyImageTask
 
 ``CpSkyImageTask`` preprocesses exposures after :lsst-task:`~lsst.ip.isr.IsrTask` to mask detections so a cleaner background estimate can be measured.
 
-.. _lsst.cp.pipe.cpSkyTask.CpSkyImageTask-processing-summary:
+.. _lsst.cp.pipe.CpSkyImageTask-processing-summary:
 
 Processing summary
 ==================
@@ -16,23 +16,23 @@ Processing summary
 #. Run :lsst-task:`~lsst.pipe.tasks.background.MaskObjectsTask` to identify and mask sources in the image.
 #. Construct a single-detector `~lsst.pipe.tasks.background.FocalPlaneBackground` model from the detection clean image.
 
-.. _lsst.cp.pipe.cpSkyTask.CpSkyImageTask-api:
+.. _lsst.cp.pipe.CpSkyImageTask-api:
 
 Python API summary
 ==================
 
-.. lsst-task-api-summary:: lsst.cp.pipe.cpSkyTask.CpSkyImageTask
+.. lsst-task-api-summary:: lsst.cp.pipe.CpSkyImageTask
 
-.. _lsst.cp.pipe.cpSkyTask.CpSkyImageTask-subtasks:
+.. _lsst.cp.pipe.CpSkyImageTask-subtasks:
 
 Retargetable subtasks
 =====================
 
-.. lsst-task-config-subtasks:: lsst.cp.pipe.cpSkyTask.CpSkyImageTask
+.. lsst-task-config-subtasks:: lsst.cp.pipe.CpSkyImageTask
 
-.. _lsst.cp.pipe.cpSkyTask.CpSkyImageTask-configs:
+.. _lsst.cp.pipe.CpSkyImageTask-configs:
 
 Configuration fields
 ====================
 
-.. lsst-task-config-fields:: lsst.cp.pipe.cpSkyTask.CpSkyImageTask
+.. lsst-task-config-fields:: lsst.cp.pipe.CpSkyImageTask

--- a/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpSkyScaleMeasureTask.rst
+++ b/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpSkyScaleMeasureTask.rst
@@ -1,4 +1,4 @@
-.. lsst-task-topic:: lsst.cp.pipe.cpSkyTask.CpSkyScaleMeasureTask
+.. lsst-task-topic:: lsst.cp.pipe.CpSkyScaleMeasureTask
 
 #####################
 CpSkyScaleMeasureTask
@@ -6,7 +6,7 @@ CpSkyScaleMeasureTask
 
 ``CpSkyScaleMeasureTask`` merges the `lsst.pipe.tasks.background.FocalPlaneBackground` models generated per-detector into a single full-focal plane model.
 
-.. _lsst.cp.pipe.cpSkyTask.CpSkyScaleMeasureTask-processing-summary:
+.. _lsst.cp.pipe.CpSkyScaleMeasureTask-processing-summary:
 
 Processing summary
 ==================
@@ -16,23 +16,23 @@ Processing summary
 #. Merges per-detector models together.
 #. Measures the median of the model statistics image to determine the per-exposure scale factor.
 
-.. _lsst.cp.pipe.cpSkyTask.CpSkyScaleMeasureTask-api:
+.. _lsst.cp.pipe.CpSkyScaleMeasureTask-api:
 
 Python API summary
 ==================
 
-.. lsst-task-api-summary:: lsst.cp.pipe.cpSkyTask.CpSkyScaleMeasureTask
+.. lsst-task-api-summary:: lsst.cp.pipe.CpSkyScaleMeasureTask
 
-.. _lsst.cp.pipe.cpSkyTask.CpSkyScaleMeasureTask-subtasks:
+.. _lsst.cp.pipe.CpSkyScaleMeasureTask-subtasks:
 
 Retargetable subtasks
 =====================
 
-.. lsst-task-config-subtasks:: lsst.cp.pipe.cpSkyTask.CpSkyScaleMeasureTask
+.. lsst-task-config-subtasks:: lsst.cp.pipe.CpSkyScaleMeasureTask
 
-.. _lsst.cp.pipe.cpSkyTask.CpSkyScaleMeasureTask-configs:
+.. _lsst.cp.pipe.CpSkyScaleMeasureTask-configs:
 
 Configuration fields
 ====================
 
-.. lsst-task-config-fields:: lsst.cp.pipe.cpSkyTask.CpSkyScaleMeasureTask
+.. lsst-task-config-fields:: lsst.cp.pipe.CpSkyScaleMeasureTask

--- a/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpSkySubtractBackgroundTask.rst
+++ b/doc/lsst.cp.pipe/tasks/lsst.cp.pipe.CpSkySubtractBackgroundTask.rst
@@ -1,4 +1,4 @@
-.. lsst-task-topic:: lsst.cp.pipe.cpSkyTask.CpSkySubtractBackgroundTask
+.. lsst-task-topic:: lsst.cp.pipe.CpSkySubtractBackgroundTask
 
 ###########################
 CpSkySubtractBackgroundTask
@@ -6,7 +6,7 @@ CpSkySubtractBackgroundTask
 
 ``CpSkySubtractBackgroundTask`` subtracts the scaled full-focal plane model created by :lsst-task:`~lsst.cp.pipe.CpSkyScaleMeasureTask` from the per-detector images created by :lsst-task:`~lsst.cp.pipe.CpSkyImageTask`.
 
-.. _lsst.cp.pipe.cpSkyTask.CpSkySubtractBackgroundTask-processing-summary:
+.. _lsst.cp.pipe.CpSkySubtractBackgroundTask-processing-summary:
 
 Processing summary
 ==================
@@ -16,23 +16,23 @@ Processing summary
 #. Subtract the scaled focal-plane model from the per-detector image.
 #. Remeasure the residual background.
 
-.. _lsst.cp.pipe.cpSkyTask.CpSkySubtractBackgroundTask-api:
+.. _lsst.cp.pipe.CpSkySubtractBackgroundTask-api:
 
 Python API summary
 ==================
 
-.. lsst-task-api-summary:: lsst.cp.pipe.cpSkyTask.CpSkySubtractBackgroundTask
+.. lsst-task-api-summary:: lsst.cp.pipe.CpSkySubtractBackgroundTask
 
-.. _lsst.cp.pipe.cpSkyTask.CpSkySubtractBackgroundTask-subtasks:
+.. _lsst.cp.pipe.CpSkySubtractBackgroundTask-subtasks:
 
 Retargetable subtasks
 =====================
 
-.. lsst-task-config-subtasks:: lsst.cp.pipe.cpSkyTask.CpSkySubtractBackgroundTask
+.. lsst-task-config-subtasks:: lsst.cp.pipe.CpSkySubtractBackgroundTask
 
-.. _lsst.cp.pipe.cpSkyTask.CpSkySubtractBackgroundTask-configs:
+.. _lsst.cp.pipe.CpSkySubtractBackgroundTask-configs:
 
 Configuration fields
 ====================
 
-.. lsst-task-config-fields:: lsst.cp.pipe.cpSkyTask.CpSkySubtractBackgroundTask
+.. lsst-task-config-fields:: lsst.cp.pipe.CpSkySubtractBackgroundTask


### PR DESCRIPTION
The tasks are all available in the `lsst.cp.pipe` namespace and the docs need to reference them there.