### PR TITLE
DM-45201: Fix fiber spectrograph fitting in CpMonochromatorScanTask

### DIFF
--- a/python/lsst/cp/pipe/cpFilterScan.py
+++ b/python/lsst/cp/pipe/cpFilterScan.py
@@ -415,19 +415,16 @@ class CpMonochromatorScanTask(pipeBase.PipelineTask):
         # Search for the 50% points for FWHM estimate.  Search for the
         # 10% points to define the range for Gaussian fit.
         for dx in range(maxIdx, maxIdx + peakBoxSize):
-            if not highHM:
-                if normFlux[dx] < 0.5:
-                    highHM = dx
-            if not high:
-                if normFlux[dx] < 0.1:
-                    high = dx
+            if normFlux[dx] >= 0.5:
+                highHM = dx
+            if normFlux[dx] >= 0.1:
+                high = dx
+
         for dx in range(maxIdx, maxIdx - peakBoxSize, -1):
-            if not lowHM:
-                if normFlux[dx] > 0.5:
-                    lowHM = dx - 1
-            if not low:
-                if normFlux[dx] > 0.1:
-                    low = dx - 1
+            if normFlux[dx] >= 0.5:
+                lowHM = dx - 1
+            if normFlux[dx] >= 0.1:
+                low = dx - 1
 
         # The above search should be fine, but let's ensure we have
         # reasonable limits.


### PR DESCRIPTION
The previous version of this code searched for points that we below the thresholds in the positive wavelength direction, assigning the endpoint if it hadn't already been set.  This worked fine.  The search in the negative wavelength direction, however, searched for the first pixel above the threshold, and assigned the endpoint if it wasn't already set.  This would find the first pixel lower than the peak, set that as the endpoint, and due to the `if not None` checks, never set any lower pixel as the endpoint.  This resulted in the fitting code only getting slightly more than the upper-half of the profile.
The updated code searches both directions for pixels above or equal to the thresholds, allowing newer endpoints to overwrite those that exist.  This fixes the search in the negative wavelength direction, supplying the fitting code with a much more symmetric profile to fit, fixing the fit error.