### PR TITLE
DM-46308: Updates to PTC fitting, including doAmpOffsetGainRatioFixup for new IsrTaskLSST

### DIFF
--- a/python/lsst/cp/pipe/cpCombine.py
+++ b/python/lsst/cp/pipe/cpCombine.py
@@ -334,12 +334,7 @@ class CalibCombineTask(pipeBase.PipelineTask):
                     raise RuntimeError(f"Could not identify a scaling for input {index}"
                                        f" detector {detectorId}")
 
-                if self.config.scalingLevel == "DETECTOR":
-                    if visitId not in inputScales["expScale"][detectorId]:
-                        raise RuntimeError(f"Could not identify a scaling for input {index}"
-                                           f"detector {detectorId} visit {visitId}")
-                    scale = inputScales["expScale"][detectorId][visitId]
-                elif self.config.scalingLevel == "AMP":
+                if self.config.scalingLevel in ("DETECTOR", "AMP"):
                     scale = [inputScales["expScale"][detectorId][amp.getName()][visitId]
                              for amp in inputDetector]
                 else:

--- a/python/lsst/cp/pipe/ptc/cpPtcExtract.py
+++ b/python/lsst/cp/pipe/ptc/cpPtcExtract.py
@@ -540,6 +540,7 @@ class PhotonTransferCurveExtractTask(pipeBase.PipelineTask):
                     self.log.warning("Already found 2 exposures at %s %f. Ignoring exposures: %s",
                                      self.config.matchExposuresType, expTime,
                                      ", ".join(str(i[1]) for i in exposures[2:]))
+            self.log.info("Extracting PTC data from flat pair %d, %d", expId1, expId2)
             # Mask pixels at the edge of the detector or of each amp
             if self.config.numEdgeSuspect > 0:
                 isrTask.maskEdges(exp1, numEdgePixels=self.config.numEdgeSuspect,

--- a/python/lsst/cp/pipe/ptc/cpPtcExtract.py
+++ b/python/lsst/cp/pipe/ptc/cpPtcExtract.py
@@ -563,6 +563,12 @@ class PhotonTransferCurveExtractTask(pipeBase.PipelineTask):
 
                 auxDict[key] = value
 
+            # Pull key visitInfo data into the auxDict.
+            visitInfo = exp1.info.getVisitInfo()
+            auxDict["observationType"] = visitInfo.getObservationType()
+            auxDict["observationReason"] = visitInfo.getObservationReason()
+            auxDict["scienceProgram"] = visitInfo.getScienceProgram()
+
             nAmpsNan = 0
             partialPtcDataset = PhotonTransferCurveDataset(
                 ampNames, 'PARTIAL',

--- a/python/lsst/cp/pipe/ptc/cpPtcExtract.py
+++ b/python/lsst/cp/pipe/ptc/cpPtcExtract.py
@@ -722,6 +722,12 @@ class PhotonTransferCurveExtractTask(pipeBase.PipelineTask):
                 else:
                     photoCharge = np.nan
 
+                # Get amp offsets if available.
+                ampOffsetKey = f"LSST ISR AMPOFFSET PEDESTAL {ampName}"
+                ampOffset1 = exp1.metadata.get(ampOffsetKey, np.nan)
+                ampOffset2 = exp2.metadata.get(ampOffsetKey, np.nan)
+                ampOffset = (ampOffset1 + ampOffset2) / 2.0
+
                 partialPtcDataset.setAmpValuesPartialDataset(
                     ampName,
                     inputExpIdPair=(expId1, expId2),
@@ -729,6 +735,7 @@ class PhotonTransferCurveExtractTask(pipeBase.PipelineTask):
                     rawMean=muDiff,
                     rawVar=varDiff,
                     photoCharge=photoCharge,
+                    ampOffset=ampOffset,
                     expIdMask=expIdMask,
                     covariance=covArray[0, :, :],
                     covSqrtWeights=covSqrtWeights[0, :, :],

--- a/python/lsst/cp/pipe/ptc/cpPtcSolve.py
+++ b/python/lsst/cp/pipe/ptc/cpPtcSolve.py
@@ -551,7 +551,7 @@ class PhotonTransferCurveSolveTask(pipeBase.PipelineTask):
                 dataset.finalMeans[ampName] = np.repeat(np.nan, lenInputTimes)
                 continue
 
-            muAtAmp = dataset.rawMeans[ampName]
+            muAtAmp = dataset.rawMeans[ampName].copy()
             maskAtAmp = dataset.expIdMask[ampName]
             if len(maskAtAmp) == 0:
                 maskAtAmp = np.repeat(True, len(muAtAmp))
@@ -650,9 +650,12 @@ class PhotonTransferCurveSolveTask(pipeBase.PipelineTask):
             dataset.noiseMatrix[ampName] = fitResults['fullModel']['noiseMatrix']
             dataset.noiseMatrixNoB[ampName] = fitResults['fullModelNoB']['noiseMatrix']
 
-            dataset.finalVars[ampName] = covAtAmp[:, 0, 0]
-            dataset.finalModelVars[ampName] = dataset.covariancesModel[ampName][:, 0, 0]
-            dataset.finalMeans[ampName] = muAtAmp
+            dataset.finalVars[ampName] = covAtAmp[:, 0, 0].copy()
+            dataset.finalVars[ampName][~maskAtAmp] = np.nan
+            dataset.finalModelVars[ampName] = dataset.covariancesModel[ampName][:, 0, 0].copy()
+            dataset.finalModelVars[ampName][~maskAtAmp] = np.nan
+            dataset.finalMeans[ampName] = muAtAmp.copy()
+            dataset.finalMeans[ampName][~maskAtAmp] = np.nan
 
         return dataset
 

--- a/python/lsst/cp/pipe/ptc/cpPtcSolve.py
+++ b/python/lsst/cp/pipe/ptc/cpPtcSolve.py
@@ -1214,6 +1214,15 @@ class PhotonTransferCurveSolveTask(pipeBase.PipelineTask):
                             # This jump is fine; continue.
                             continue
 
+                        self.log.info(
+                            "Found a jump of %.2f for amp %s, greater than %.2f. Masking points higher "
+                            "than %.2f ADU.",
+                            deltaADU,
+                            ampName,
+                            maxDeltaADUInitialPtcOutlierFit,
+                            meanVecSorted[useMask[useIndex - 1]],
+                        )
+
                         # Mark all further points bad.
                         newMask[usePoint:] = False
                         break

--- a/python/lsst/cp/pipe/ptc/cpPtcSolve.py
+++ b/python/lsst/cp/pipe/ptc/cpPtcSolve.py
@@ -382,24 +382,7 @@ class PhotonTransferCurveSolveTask(pipeBase.PipelineTask):
                 detectorMeans[i] = np.mean(arr[good])
 
         index = np.argsort(detectorMeans)
-
-        for ampName in ampNames:
-            datasetPtc.inputExpIdPairs[ampName] = np.array(
-                datasetPtc.inputExpIdPairs[ampName]
-            )[index].tolist()
-            datasetPtc.rawExpTimes[ampName] = datasetPtc.rawExpTimes[ampName][index]
-            datasetPtc.rawMeans[ampName] = datasetPtc.rawMeans[ampName][index]
-            datasetPtc.rawVars[ampName] = datasetPtc.rawVars[ampName][index]
-            datasetPtc.rowMeanVariance[ampName] = datasetPtc.rowMeanVariance[ampName][index]
-            datasetPtc.photoCharges[ampName] = datasetPtc.photoCharges[ampName][index]
-            datasetPtc.histVars[ampName] = datasetPtc.histVars[ampName][index]
-            datasetPtc.histChi2Dofs[ampName] = datasetPtc.histChi2Dofs[ampName][index]
-            datasetPtc.kspValues[ampName] = datasetPtc.kspValues[ampName][index]
-            datasetPtc.expIdMask[ampName] = datasetPtc.expIdMask[ampName][index]
-            datasetPtc.covariances[ampName] = datasetPtc.covariances[ampName][index]
-            datasetPtc.covariancesSqrtWeights[ampName] = datasetPtc.covariancesSqrtWeights[ampName][index]
-        for key, value in datasetPtc.auxValues.items():
-            datasetPtc.auxValues[key] = value[index]
+        datasetPtc.sort(index)
 
         if self.config.ptcFitType == "FULLCOVARIANCE":
             # Fit the measured covariances vs mean signal to

--- a/python/lsst/cp/pipe/utils.py
+++ b/python/lsst/cp/pipe/utils.py
@@ -1387,6 +1387,9 @@ def ampOffsetGainRatioFixup(ptc, minAdu, maxAdu, log=None):
     """
     # We need to find the reference amplifier.
     # Find an amp near the middle to use as a pivot.
+    if log is None:
+        log = logging.getLogger(__name__)
+
     gainArray = np.zeros(len(ptc.ampNames))
     for i, ampName in enumerate(ptc.ampNames):
         gainArray[i] = ptc.gain[ampName]
@@ -1399,8 +1402,7 @@ def ampOffsetGainRatioFixup(ptc, minAdu, maxAdu, log=None):
         midAmp = good[st[int(0.5*len(good))]]
         midAmpName = ptc.ampNames[midAmp]
 
-        if log:
-            log.info("Using amplifier %s as the pivot for doLinearityGainRatioFixup.", midAmpName)
+        log.info("Using amplifier %s as the pivot for doLinearityGainRatioFixup.", midAmpName)
 
         # First pass, we need to compute the corrections.
         corrections = {}
@@ -1420,9 +1422,8 @@ def ampOffsetGainRatioFixup(ptc, minAdu, maxAdu, log=None):
                 & (ptc.expIdMask[midAmpName])
             )
             if use.sum() < 3:
-                if log:
-                    log.warning("Not enough good amp offset measurements to fix up amp %s "
-                                "gains from amp ratios.", ampName)
+                log.warning("Not enough good amp offset measurements to fix up amp %s "
+                            "gains from amp ratios.", ampName)
                 continue
 
             ratios = 1. / (deltas / ptc.finalMeans[midAmpName] + 1.0)
@@ -1447,18 +1448,16 @@ def ampOffsetGainRatioFixup(ptc, minAdu, maxAdu, log=None):
 
             correction = corrections[ampName] / medCorrection
             newGain = ptc.gain[ampName] * correction
-            if log:
-                log.info(
-                    "Adjusting gain from amplifier %s by factor of %.5f (from %.5f to %.5f)",
-                    ampName,
-                    correction,
-                    ptc.gain[ampName],
-                    newGain,
-                )
+            log.info(
+                "Adjusting gain from amplifier %s by factor of %.5f (from %.5f to %.5f)",
+                ampName,
+                correction,
+                ptc.gain[ampName],
+                newGain,
+            )
             # Copying the value should not be necessary, but we record
             # it just in case.
             ptc.gainUnadjusted[ampName] = ptc.gain[ampName]
             ptc.gain[ampName] = newGain
     else:
-        if log:
-            log.warning("Cannot apply ampOffsetGainRatioFixup with fewer than 2 good amplifiers.")
+        log.warning("Cannot apply ampOffsetGainRatioFixup with fewer than 2 good amplifiers.")

--- a/python/lsst/cp/pipe/utils.py
+++ b/python/lsst/cp/pipe/utils.py
@@ -193,6 +193,12 @@ def makeMockFlats(expTime, gain=1.0, readNoiseElectrons=5, fluxElectrons=1000,
         flatExp1.metadata[key] = value
         flatExp2.metadata[key] = value
 
+        key = f"LSST ISR AMPOFFSET PEDESTAL {ampName}"
+        value = 0.0
+
+        flatExp1.metadata[key] = value
+        flatExp2.metadata[key] = value
+
     return flatExp1, flatExp2
 
 

--- a/python/lsst/cp/pipe/utils.py
+++ b/python/lsst/cp/pipe/utils.py
@@ -1396,6 +1396,8 @@ def ampOffsetGainRatioFixup(ptc, minAdu, maxAdu, log=None):
     if log is None:
         log = logging.getLogger(__name__)
 
+    # We first check for which amps have gain measurements
+    # (fully bad amps are filled with NaN for gain.)
     gainArray = np.zeros(len(ptc.ampNames))
     for i, ampName in enumerate(ptc.ampNames):
         gainArray[i] = ptc.gain[ampName]
@@ -1404,11 +1406,14 @@ def ampOffsetGainRatioFixup(ptc, minAdu, maxAdu, log=None):
     if len(good) > 1:
         # This only works with more than 1 good amp.
 
+        # We sort the gains and take the one that is closest
+        # to the median to use as the reference amplifier for
+        # gain ratios.
         st = np.argsort(gainArray[good])
         midAmp = good[st[int(0.5*len(good))]]
         midAmpName = ptc.ampNames[midAmp]
 
-        log.info("Using amplifier %s as the pivot for doLinearityGainRatioFixup.", midAmpName)
+        log.info("Using amplifier %s as the reference for doLinearityGainRatioFixup.", midAmpName)
 
         # First pass, we need to compute the corrections.
         corrections = {}

--- a/python/lsst/cp/pipe/utils.py
+++ b/python/lsst/cp/pipe/utils.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-__all__ = ['ddict2dict', 'CovFastFourierTransform', 'getReadNoise']
+__all__ = ['ddict2dict', 'CovFastFourierTransform', 'getReadNoise', 'ampOffsetGainRatioFixup']
 
 
 import galsim
@@ -1367,3 +1367,98 @@ def getReadNoise(exposure, ampName, taskMetadata=None, log=None):
     log.warning("Median readout noise from ISR metadata for amp %s "
                 "could not be found.", ampName)
     return np.nan
+
+
+def ampOffsetGainRatioFixup(ptc, minAdu, maxAdu, log=None):
+    """Apply gain ratio fixup using amp offsets.
+
+    Parameters
+    ----------
+    ptc : `lsst.ip.isr.PhotonTransferCurveDataset`
+        Input PTC. Will be modified in place.
+    minAdu : `float`
+        Minimum number of ADU in mean of amplifier to use for
+        computing gain ratio fixup.
+    maxAdu : `float`
+        Maximum number of ADU in mean of amplifier to use for
+        computing gain ratio fixup.
+    log : `lsst.utils.logging.LsstLogAdapter`, optional
+        Log object.
+    """
+    # We need to find the reference amplifier.
+    # Find an amp near the middle to use as a pivot.
+    gainArray = np.zeros(len(ptc.ampNames))
+    for i, ampName in enumerate(ptc.ampNames):
+        gainArray[i] = ptc.gain[ampName]
+    good, = np.where(np.isfinite(gainArray))
+
+    if len(good) > 1:
+        # This only works with more than 1 good amp.
+
+        st = np.argsort(gainArray[good])
+        midAmp = good[st[int(0.5*len(good))]]
+        midAmpName = ptc.ampNames[midAmp]
+
+        if log:
+            log.info("Using amplifier %s as the pivot for doLinearityGainRatioFixup.", midAmpName)
+
+        # First pass, we need to compute the corrections.
+        corrections = {}
+        for ampName in ptc.ampNames:
+            if not np.isfinite(ptc.gain[ampName]) or ampName == midAmpName:
+                continue
+
+            ratioPtc = ptc.gain[ampName] / ptc.gain[midAmpName]
+
+            deltas = ptc.ampOffsets[ampName] - ptc.ampOffsets[midAmpName]
+            use = (
+                (ptc.expIdMask[ampName])
+                & (np.isfinite(deltas))
+                & (ptc.finalMeans[ampName] >= minAdu)
+                & (ptc.finalMeans[ampName] <= maxAdu)
+                & (np.isfinite(ptc.finalMeans[midAmpName]))
+                & (ptc.expIdMask[midAmpName])
+            )
+            if use.sum() < 3:
+                if log:
+                    log.warning("Not enough good amp offset measurements to fix up amp %s "
+                                "gains from amp ratios.", ampName)
+                continue
+
+            ratios = 1. / (deltas / ptc.finalMeans[midAmpName] + 1.0)
+            ratio = np.median(ratios[use])
+            corrections[ampName] = ratio / ratioPtc
+
+        # For the final correction, we need to make sure that the
+        # reference amplifier is included. By definition, it has a
+        # correction factor of 1.0 before any final fix.
+        corrections[midAmpName] = 1.0
+
+        # Adjust the median correction to be 1.0 so we do not
+        # change the gain of the detector on average.
+        # This is needed in case the reference amplifier is
+        # skewed in terms of offsets even though it has the median
+        # gain.
+        medCorrection = np.median([corrections[key] for key in corrections])
+
+        for ampName in ptc.ampNames:
+            if ampName not in corrections:
+                continue
+
+            correction = corrections[ampName] / medCorrection
+            newGain = ptc.gain[ampName] * correction
+            if log:
+                log.info(
+                    "Adjusting gain from amplifier %s by factor of %.5f (from %.5f to %.5f)",
+                    ampName,
+                    correction,
+                    ptc.gain[ampName],
+                    newGain,
+                )
+            # Copying the value should not be necessary, but we record
+            # it just in case.
+            ptc.gainUnadjusted[ampName] = ptc.gain[ampName]
+            ptc.gain[ampName] = newGain
+    else:
+        if log:
+            log.warning("Cannot apply ampOffsetGainRatioFixup with fewer than 2 good amplifiers.")

--- a/tests/test_ptc.py
+++ b/tests/test_ptc.py
@@ -342,6 +342,10 @@ class MeasurePhotonTransferCurveTaskTestCase(lsst.utils.tests.TestCase):
                     rtol=None,
                 )
                 self.assertFloatsAlmostEqual(
+                    ptc.ampOffsets[ampName],
+                    0.0,
+                )
+                self.assertFloatsAlmostEqual(
                     ptc.noise[ampName],
                     np.nanmedian(ptc.noiseList[ampName]) * ptc.gain[ampName],
                     rtol=0.05,

--- a/tests/test_ptc.py
+++ b/tests/test_ptc.py
@@ -278,8 +278,11 @@ class MeasurePhotonTransferCurveTaskTestCase(lsst.utils.tests.TestCase):
 
         for amp in self.ampNames:
             self.assertAlmostEqual(ptc.gain[amp], inputGain, places=2)
-            for v1, v2 in zip(varStandard[amp], ptc.finalVars[amp]):
-                self.assertAlmostEqual(v1 / v2, 1.0, places=1)
+            self.assertFloatsAlmostEqual(
+                np.asarray(varStandard[amp])[ptc.expIdMask[amp]] / ptc.finalVars[amp][ptc.expIdMask[amp]],
+                1.0,
+                rtol=1e-4,
+            )
 
             # Check that the PTC turnoff is correctly computed.
             # This will be different for the C:0,0 amp.

--- a/tests/test_ptc.py
+++ b/tests/test_ptc.py
@@ -822,6 +822,29 @@ class MeasurePhotonTransferCurveTaskTestCase(lsst.utils.tests.TestCase):
                     exposurePair.gain[ampName], inputGain, delta=0.04
                 )
 
+        # Run through the solver and check that the gains from flat pairs
+        # are recorded in the gainList.
+        solveConfig = self.defaultConfigSolve
+        solveConfig.ptcFitType = "EXPAPPROXIMATION"
+        solveTask = cpPipe.ptc.PhotonTransferCurveSolveTask(config=solveConfig)
+
+        resultsSolve = solveTask.run(
+            resultsExtract.outputCovariances,
+            camera=FakeCamera([self.flatExp1.getDetector()]),
+        )
+        ptc = resultsSolve.outputPtcDataset
+
+        for i in range(len(ptc.inputExpIdPairs)):
+            for ampName in self.ampNames:
+                if np.isnan(ptc.gainList[ampName][i]):
+                    continue
+                self.assertAlmostEqual(
+                    ptc.gainList[ampName][i], inputGain, delta=0.04,
+                )
+                self.assertAlmostEqual(
+                    ptc.noiseList[ampName][i], np.sqrt(self.noiseSq) / self.gain,
+                )
+
     def test_getGainFromFlatPair(self):
         for gainCorrectionType in [
             "NONE",


### PR DESCRIPTION
This PR implements a bunch of small updates found in the development of DM-45856, including the `doAmpOffsetGainRatioFixup` that uses flat-pair amp offsets to fix up noisy gain ratios determined from the individual amplifier PTC fitting.