### PR TITLE
DM-46546: Linearity fit residual test should use linear fit parameters as initial guess

### DIFF
--- a/python/lsst/cp/pipe/cpLinearitySolve.py
+++ b/python/lsst/cp/pipe/cpLinearitySolve.py
@@ -685,7 +685,7 @@ class LinearitySolveTask(pipeBase.PipelineTask):
                 residuals = np.full_like(linearizeModel, np.nan)
             else:
                 postLinearFit, _, _, _ = irlsFit(
-                    [0.0, 100.0],
+                    linearFit,
                     inputAbscissa[mask],
                     linearizeModel[mask],
                     funcPolynomial,


### PR DESCRIPTION
This makes sure that when using the photodiode (much larger scaling) that things converge correctly when checking residuals.