### PR TITLE
DM-47636: Switch CROSSTALK masking to use subtrahend masking

### DIFF
--- a/python/lsst/cp/pipe/ptc/cpPtcExtract.py
+++ b/python/lsst/cp/pipe/ptc/cpPtcExtract.py
@@ -939,7 +939,7 @@ class PhotonTransferCurveExtractTask(pipeBase.PipelineTask):
 
         # Get the pixels in the mask planes of the difference image
         # that were ignored by the clipping algorithm
-        wDiff = np.where(diffIm.getMask().getArray() == 0, 1, 0)
+        wDiff = np.where(diffIm.mask.array & imStatsCtrl.getAndMask() == 0, 1, 0)
         # Combine the two sets of pixels ('1': use; '0': don't use)
         # into a final weight matrix to be used in the covariance
         # calculations below.


### PR DESCRIPTION
Only exclude mask planes we've asked to exclude.