### PR TITLE
DM-49663: Further bitrot in summit calibration checkouts

### DIFF
--- a/pipelines/LATISS/cpPtc.yaml
+++ b/pipelines/LATISS/cpPtc.yaml
@@ -7,3 +7,4 @@ tasks:
     class: lsst.cp.pipe.ptc.PhotonTransferCurveExtractPairTask
     config:
       efdSalIndex: 201
+      useEfdPhotodiodeData: false


### PR DESCRIPTION
Disable electrometer for LATISS PTC (as it's not set up to run on daily checkout).